### PR TITLE
Fix home templates

### DIFF
--- a/home/templates/home/event_detail.html
+++ b/home/templates/home/event_detail.html
@@ -49,7 +49,7 @@
         <p><strong>Categories:</strong>{% for cat in event.categories.all %} {{ cat }} {% endfor %}</p>
         <br>
 
-        <p>{{ event.description }}</p>
+        <p>{{ event.description|linebreaksbr|urlizetrunc:25 }}</p>
         <br>
         <h3><strong>Speakers:</strong></h3>
 

--- a/home/templates/home/includes/session_card.html
+++ b/home/templates/home/includes/session_card.html
@@ -4,7 +4,7 @@
       <div class="card-body">
         <h5 class="card-title">{{ session.title }}</h5>
         <p class="card-text">
-          {{ session.description|urlize|linebreaksbr }}
+          {{ session.description|linebreaksbr|urlizetrunc:25|truncatewords_html:60 }}
         </p>
         <br />
         <h6>Applications Open</h6>

--- a/home/templates/home/prerelease/session_detail.html
+++ b/home/templates/home/prerelease/session_detail.html
@@ -37,7 +37,7 @@
         <dt class="col-sm-3">End:</dt>
         <dd class="col-sm-9">{{ session.end_date|date:"Y-m-d" }}</dd>
       </dl>
-      <p>{{ session.description }}</p>
+      <p>{{ session.description|linebreaksbr|urlizetrunc:25 }}</p>
       {% if session.is_accepting_applications %}
         <br />
         <h2>You have {{ session.application_end_date|timeuntil}} to submit your application</h2>


### PR DESCRIPTION
* Respect the linebreaks in the session description

* Limit the number of words on the cards for sessions.

* Update event detail view to have line breaks on the description and to urlize links.