### PR TITLE
Verify our identity on Mastodon by adding rel="me" to Mastodon link.

### DIFF
--- a/home/templates/home/home_page.html
+++ b/home/templates/home/home_page.html
@@ -35,7 +35,7 @@
         <a class="landing-links twitter" href="https://twitter.com/djangonautspace" target="_blank">
             <i class="fa-brands fa-twitter" aria-label="Twitter"></i>
         </a>
-        <a class="landing-links mastodon" href="https://fosstodon.org/@djangonaut@indieweb.social" target="_blank">
+        <a rel="me" class="landing-links mastodon" href="https://indieweb.social/@djangonaut" target="_blank">
             <i class="fa-brands fa-mastodon" aria-label="Mastodon"></i>
         </a>
         <a class="landing-links github" href="https://github.com/djangonaut-space/" target="_blank">


### PR DESCRIPTION
Want to verify our website against our Mastodon account. It might be this simple 🤷‍♀️ 

https://indieweb.social/settings/verification

### Instructions

Verifying your identity on Mastodon is for everyone. Based on open web standards, now and forever free. All you need is a personal website that people recognize you by. When you link to this website from your profile, we will check that the website links back to your profile and show a visual indicator on it.

HERE'S HOW
Copy and paste the code below into the HTML of your website. Then add the address of your website into one of the extra fields on your profile from the "Edit profile" tab and save changes.

`<a rel="me" href="https://indieweb.social/@djangonaut">Mastodon</a>`

Tip: The link on your website can be invisible. The important part is rel="me" which prevents impersonation on websites with user-generated content. You can even use a link tag in the header of the page instead of a, but the HTML must be accessible without executing JavaScript.