### PR TITLE
Improve the session and event pages (mostly around timezone stuff)

### DIFF
--- a/home/models.py
+++ b/home/models.py
@@ -212,14 +212,28 @@ class Session(models.Model):
     def __str__(self):
         return self.title
 
+    def application_start_anywhere_on_earth(self):
+        aoe_early_timezone = datetime.timezone(datetime.timedelta(hours=12))
+        return datetime.datetime.combine(
+            self.application_start_date,
+            datetime.datetime.min.time(),
+            tzinfo=aoe_early_timezone,
+        )
+
+    def application_end_anywhere_on_earth(self):
+        aoe_late_timezone = datetime.timezone(datetime.timedelta(hours=-12))
+        return datetime.datetime.combine(
+            self.application_end_date,
+            datetime.datetime.max.time(),
+            tzinfo=aoe_late_timezone,
+        )
+
     def is_accepting_applications(self):
         """Determine if the current date is within the application window"""
-        aoe_early_timezone = datetime.timezone(datetime.timedelta(hours=12))
-        aoe_late_timezone = datetime.timezone(datetime.timedelta(hours=-12))
-        today_early_aoe = datetime.datetime.now(tz=aoe_early_timezone).date()
-        today_late_aoe = datetime.datetime.now(tz=aoe_late_timezone).date()
-        return (self.application_start_date <= today_early_aoe) and (
-            today_late_aoe <= self.application_end_date
+        return (
+            self.application_start_anywhere_on_earth()
+            <= timezone.now()
+            <= self.application_end_anywhere_on_earth()
         )
 
     def get_absolute_url(self):

--- a/home/templates/home/prerelease/event_detail.html
+++ b/home/templates/home/prerelease/event_detail.html
@@ -2,6 +2,7 @@
 {% load i18n wagtailcore_tags static %}
 {# Load the tag library #}
 {% load django_bootstrap5 %}
+{% load tz %}
 
 {# Load CSS and JavaScript #}
 {% bootstrap_css %}
@@ -25,9 +26,11 @@
   </div>
   <div class="row">
     <div class="col">
+        {% localtime on %}
         <p><strong>Start:</strong> {{ event.start_time|date:"M d, Y H:i e" }}</p>
         <p><strong>End:</strong> {{ event.end_time|date:"M d, Y H:i e" }}</p>
-        <p><strong>Location:</strong> {{ event.location }}</p>
+        {% endlocaltime %}
+        <p><strong>Location:</strong> {{ event.location|urlizetrunc:25 }}</p>
         <br>
         <p>{{ event.description|linebreaksbr|urlizetrunc:25 }}</p>
     </div>

--- a/home/templates/home/prerelease/event_list.html
+++ b/home/templates/home/prerelease/event_list.html
@@ -28,7 +28,7 @@
             </div>
         </div>
         <h2>Upcoming Events</h2>
-        <div class="g-2 g-lg-3 row justify-content-evenly pt-4">
+        <div class="g-2 g-lg-3 row justify-content-evenly pt-4 pb-4">
 
             {% for event in upcoming_events %}
             {% include 'home/includes/event_card.html' %}

--- a/home/templates/home/prerelease/session_detail.html
+++ b/home/templates/home/prerelease/session_detail.html
@@ -27,9 +27,9 @@
     <div class="col">
       <dl class="row">
         <dt class="col-sm-3">Applications Open:</dt>
-        <dd class="col-sm-9">{{ session.application_start_date|date:"M d, Y" }}</dd>
+        <dd class="col-sm-9">{{ session.application_start_date|date:"M d, Y" }} AOE</dd>
         <dt class="col-sm-3">Applications Close:</dt>
-        <dd class="col-sm-9">{{ session.application_end_date|date:"M d, Y" }}</dd>
+        <dd class="col-sm-9">{{ session.application_end_date|date:"M d, Y" }} AOE</dd>
         <dt class="col-sm-3">Invitations Sent:</dt>
         <dd class="col-sm-9">{{ session.invitation_date|date:"M d, Y" }}</dd>
         <dt class="col-sm-3">Start:</dt>
@@ -40,7 +40,7 @@
       <p>{{ session.description|linebreaksbr|urlizetrunc:25 }}</p>
       {% if session.is_accepting_applications %}
         <br />
-        <h2>You have {{ session.application_end_date|timeuntil}} to submit your application</h2>
+        <h2>You have {{ session.application_end_anywhere_on_earth|timeuntil}} to submit your application</h2>
         <br />
         <a href="{{ session.application_url }}" target="_blank" class="btn btn-success btn-lg">Apply</a>
       {% endif %}

--- a/home/tests/test_event_views.py
+++ b/home/tests/test_event_views.py
@@ -1,14 +1,16 @@
-from datetime import datetime, timezone
+from datetime import datetime
+from datetime import timezone as dt_timezone
 
 from django.test import Client, TestCase
 from django.urls import reverse
+from django.utils import timezone
 from freezegun import freeze_time
 
 from home.models import Event
 
 
 @freeze_time("2012-01-14")
-class EventListViewTests(TestCase):
+class EventViewTests(TestCase):
     def setUp(self):
         self.client = Client()
 
@@ -17,9 +19,9 @@ class EventListViewTests(TestCase):
         return Event.objects.create(
             title="Testathon 5.0",
             slug="testathon-5",
-            start_time=datetime(2023, 2, 1, 10, 0, tzinfo=timezone.utc),
-            end_time=datetime(2023, 2, 1, 11, 0, tzinfo=timezone.utc),
-            location="zoom",
+            start_time=datetime(2023, 2, 1, 10, 0, tzinfo=dt_timezone.utc),
+            end_time=datetime(2023, 2, 1, 11, 0, tzinfo=dt_timezone.utc),
+            location="https://zoom.link",
             status=Event.SCHEDULED,
         )
 
@@ -28,24 +30,22 @@ class EventListViewTests(TestCase):
         return Event.objects.create(
             title="Coffee Chat",
             slug="coffee-chat",
-            start_time=datetime(2010, 2, 1, 10, 0, tzinfo=timezone.utc),
-            end_time=datetime(2010, 2, 1, 11, 0, tzinfo=timezone.utc),
+            start_time=datetime(2010, 2, 1, 10, 0, tzinfo=dt_timezone.utc),
+            end_time=datetime(2010, 2, 1, 11, 0, tzinfo=dt_timezone.utc),
             location="zoom",
             status=Event.SCHEDULED,
         )
 
-    def test_no_events(self):
-        url = reverse("event_list")
-        response = self.client.get(url)
+    def test_list_no_events(self):
+        response = self.client.get(reverse("event_list"))
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed("home/prerelease/event_list.html")
         self.assertContains(response, "No upcoming events.")
         self.assertContains(response, "No past events.")
 
-    def test_upcoming_events_no_past(self):
+    def test_list_upcoming_events_no_past(self):
         upcoming_event = self.create_upcoming_event()
-        url = reverse("event_list")
-        response = self.client.get(url)
+        response = self.client.get(reverse("event_list"))
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed("home/prerelease/event_list.html")
         self.assertNotContains(response, "No upcoming events.")
@@ -53,11 +53,10 @@ class EventListViewTests(TestCase):
         self.assertContains(response, upcoming_event.title)
         self.assertContains(response, upcoming_event.get_absolute_url())
 
-    def test_upcoming_events_and_past(self):
+    def test_list_upcoming_events_and_past(self):
         upcoming_event = self.create_upcoming_event()
         past_event = self.create_past_event()
-        url = reverse("event_list")
-        response = self.client.get(url)
+        response = self.client.get(reverse("event_list"))
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed("home/prerelease/event_list.html")
         self.assertNotContains(response, "No upcoming events.")
@@ -66,3 +65,15 @@ class EventListViewTests(TestCase):
         self.assertContains(response, upcoming_event.get_absolute_url())
         self.assertContains(response, past_event.title)
         self.assertContains(response, past_event.get_absolute_url())
+
+    def test_event_detail(self):
+        upcoming_event = self.create_upcoming_event()
+        timezone.activate("Europe/Berlin")  # UTC + 1
+        response = self.client.get(upcoming_event.get_absolute_url())
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed("home/prerelease/event_detail.html")
+        self.assertContains(response, "Feb 01, 2023 11:00 CET")
+        self.assertContains(
+            response, '<a href="https://zoom.link" rel="nofollow">https://zoom.link</a>'
+        )
+        timezone.deactivate()

--- a/home/tests/test_session_views.py
+++ b/home/tests/test_session_views.py
@@ -1,0 +1,73 @@
+from datetime import datetime
+
+from django.test import Client, TestCase
+from django.urls import reverse
+from freezegun import freeze_time
+
+from home.models import Session
+
+
+@freeze_time("2023-11-16")
+class SessionViewTests(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.client = Client()
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.session_application_open = Session.objects.create(
+            start_date=datetime(2024, 1, 15).date(),
+            end_date=datetime(2024, 3, 11).date(),
+            title="2024 Session 1",
+            slug="2024-session-1",
+            invitation_date=datetime(2023, 12, 1).date(),
+            application_start_date=datetime(2023, 10, 16).date(),
+            application_end_date=datetime(2023, 11, 15).date(),
+            application_url="https://apply.session1.com",
+        )
+        cls.session_application_closed = Session.objects.create(
+            start_date=datetime(2023, 7, 1).date(),
+            end_date=datetime(2024, 10, 1).date(),
+            title="2023 Pilot",
+            slug="2023-pilot",
+            invitation_date=datetime(2023, 6, 30).date(),
+            application_start_date=datetime(2023, 6, 1).date(),
+            application_end_date=datetime(2023, 6, 20).date(),
+            application_url="https://apply.pilot.com",
+        )
+
+    def test_session_list(self):
+        response = self.client.get(reverse("session_list"))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed("home/prerelease/session_list.html")
+        self.assertContains(response, self.session_application_open.application_url)
+        self.assertNotContains(
+            response, self.session_application_closed.application_url
+        )
+
+    def test_session_detail_open_application(self):
+        url = reverse(
+            "session_detail", kwargs={"slug": self.session_application_open.slug}
+        )
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed("home/prerelease/session_detail.html")
+        self.assertContains(response, self.session_application_open.application_url)
+        self.assertIn(
+            "You have 11 hours, 59 minutes to submit your application",
+            " ".join(
+                response.rendered_content.split()
+            ),  # Remove the non-breaking spaces
+        )
+
+    def test_session_detail_closed_application(self):
+        url = reverse(
+            "session_detail", kwargs={"slug": self.session_application_closed.slug}
+        )
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed("home/prerelease/session_detail.html")
+        self.assertNotContains(
+            response, self.session_application_closed.application_url
+        )


### PR DESCRIPTION
- [x] Fixed event list page padding for mobile (no gap between future and past events)
- [x] Fixed time left to apply for the session detail page
- [x] Made the session detail page explicit about AOE deadlines
- [x] Event page has time displayed in local timezone (so they don't need to do mental maths)
- [x] Event location renders links (as we use a discord link)