### PR TITLE
Clean up development requirements file.

### DIFF
--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -1,7 +1,2 @@
 -r requirements.txt
-black
-flake8
-python-dotenv==0.21.*
-django-extensions
 pre-commit
-django-debug-toolbar


### PR DESCRIPTION
The toolbar and django-extensions are already in requirements.txt flake8 and black are managed by pre-commit and not required.