### PR TITLE
This should allow tailwind to be built.

### DIFF
--- a/.github/workflows/develop_djangonaut_space.yml
+++ b/.github/workflows/develop_djangonaut_space.yml
@@ -45,9 +45,10 @@ jobs:
       SECRET_KEY: ${{ secrets.STAGING_SECRET_KEY }}
       USER: ${{ secrets.USER_ADDON }}
       WEBSITE_HTTPLOGGING_RETENTION_DAYS: '7'
-      AZURE_ACCOUNT_NAME: ${{ secrets.STAGING_AZURE_ACCOUNT_NAME }}
-      AZURE_STORAGE_NAME: ${{ secrets.STAGING_AZURE_STORAGE_NAME }}
-      AZURE_STORAGE_KEY: ${{ secrets.STAGING_AZURE_STORAGE_KEY }}
+      AZURE_ACCOUNT_NAME: ${{ secrets.AZURE_ACCOUNT_NAME }}
+      AZURE_ACCOUNT_KEY: ${{ secrets.AZURE_ACCOUNT_KEY }}
+      AZURE_MEDIA_CONTAINER: "staging-media"
+      AZURE_STATIC_CONTAINER: "staging-static"
       # collectstatic is run in the POST_BUILD_COMMAND now
       DISABLE_COLLECTSTATIC: 'true'
       # Use a custom post build command to compile the tailwind css and collectstatic

--- a/.github/workflows/develop_djangonaut_space.yml
+++ b/.github/workflows/develop_djangonaut_space.yml
@@ -45,6 +45,15 @@ jobs:
       SECRET_KEY: ${{ secrets.STAGING_SECRET_KEY }}
       USER: ${{ secrets.USER_ADDON }}
       WEBSITE_HTTPLOGGING_RETENTION_DAYS: '7'
+      AZURE_ACCOUNT_NAME: ${{ secrets.STAGING_AZURE_ACCOUNT_NAME }}
+      AZURE_STORAGE_NAME: ${{ secrets.STAGING_AZURE_STORAGE_NAME }}
+      AZURE_STORAGE_KEY: ${{ secrets.STAGING_AZURE_STORAGE_KEY }}
+      # collectstatic is run in the POST_BUILD_COMMAND now
+      DISABLE_COLLECTSTATIC: 'true'
+      # Use a custom post build command to compile the tailwind css and collectstatic
+      POST_BUILD_COMMAND: 'scripts/postbuild.sh'
+      # Allow install node to support tailwind
+      ENABLE_MULTIPLATFORM_BUILD: 'true'
     environment: staging-djangonaut-space
     runs-on: ubuntu-latest
 

--- a/.github/workflows/main_djangonaut-space.yml
+++ b/.github/workflows/main_djangonaut-space.yml
@@ -32,8 +32,7 @@ jobs:
       USER: ${{ secrets.USER }}
       WEBSITE_HTTPLOGGING_RETENTION_DAYS: '7'
       AZURE_ACCOUNT_NAME: ${{ secrets.AZURE_ACCOUNT_NAME }}
-      AZURE_STORAGE_NAME: ${{ secrets.AZURE_STORAGE_NAME }}
-      AZURE_STORAGE_KEY: ${{ secrets.AZURE_STORAGE_KEY }}
+      AZURE_ACCOUNT_KEY: ${{ secrets.AZURE_ACCOUNT_KEY }}
       # collectstatic is run in the POST_BUILD_COMMAND now
       DISABLE_COLLECTSTATIC: 'true'
       # Use a custom post build command to compile the tailwind css and collectstatic

--- a/.github/workflows/main_djangonaut-space.yml
+++ b/.github/workflows/main_djangonaut-space.yml
@@ -31,6 +31,15 @@ jobs:
       SECRET_KEY: ${{ secrets.SECRET_KEY }}
       USER: ${{ secrets.USER }}
       WEBSITE_HTTPLOGGING_RETENTION_DAYS: '7'
+      AZURE_ACCOUNT_NAME: ${{ secrets.AZURE_ACCOUNT_NAME }}
+      AZURE_STORAGE_NAME: ${{ secrets.AZURE_STORAGE_NAME }}
+      AZURE_STORAGE_KEY: ${{ secrets.AZURE_STORAGE_KEY }}
+      # collectstatic is run in the POST_BUILD_COMMAND now
+      DISABLE_COLLECTSTATIC: 'true'
+      # Use a custom post build command to compile the tailwind css and collectstatic
+      POST_BUILD_COMMAND: 'scripts/postbuild.sh'
+      # Allow install node to support tailwind
+      ENABLE_MULTIPLATFORM_BUILD: 'true'
     environment: prod-djangonaut-space
     runs-on: ubuntu-latest
 

--- a/indymeet/settings/base.py
+++ b/indymeet/settings/base.py
@@ -62,7 +62,7 @@ INSTALLED_APPS = [
     # other
     "debug_toolbar",
     "tailwind",
-    "theme"
+    "theme",
 ]
 
 MIDDLEWARE = [
@@ -115,9 +115,9 @@ DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.postgresql",
         "NAME": "djangonaut-space",
-        "USER": os.environ["USER"],
-        "PASSWORD": os.environ["PASSWORD"],
-        "HOST": os.environ["HOST"],
+        "USER": os.environ.get("USER"),
+        "PASSWORD": os.environ.get("PASSWORD"),
+        "HOST": os.environ.get("HOST"),
         "PORT": 5432,
         "OPTIONS": {},
     },

--- a/indymeet/settings/production.py
+++ b/indymeet/settings/production.py
@@ -40,8 +40,7 @@ if os.getenv("ENVIRONMENT") == "production":
     }
     # Azure Media and Static Storage Settings
     AZURE_ACCOUNT_NAME = os.environ.get("AZURE_ACCOUNT_NAME", "djangonaut")
-    AZURE_STORAGE_NAME = os.environ.get("AZURE_STORAGE_NAME", False)
-    AZURE_STORAGE_KEY = os.environ.get("AZURE_STORAGE_KEY", False)
+    AZURE_ACCOUNT_KEY = os.environ.get("AZURE_ACCOUNT_KEY", False)
     AZURE_MEDIA_CONTAINER = os.environ.get("AZURE_MEDIA_CONTAINER", "media")
     AZURE_STATIC_CONTAINER = os.environ.get("AZURE_STATIC_CONTAINER", "static")
 

--- a/indymeet/settings/production.py
+++ b/indymeet/settings/production.py
@@ -41,7 +41,7 @@ if os.getenv("ENVIRONMENT") == "production":
     # Azure Media and Static Storage Settings
     AZURE_ACCOUNT_NAME = os.environ.get("AZURE_ACCOUNT_NAME", "djangonaut")
     AZURE_STORAGE_NAME = os.environ.get("AZURE_STORAGE_NAME", False)
-    AZURE_STORAGE_KEY = os.environ.get("AZURE_STORAGE_NAME", False)
+    AZURE_STORAGE_KEY = os.environ.get("AZURE_STORAGE_KEY", False)
     AZURE_MEDIA_CONTAINER = os.environ.get("AZURE_MEDIA_CONTAINER", "media")
     AZURE_STATIC_CONTAINER = os.environ.get("AZURE_STATIC_CONTAINER", "static")
 

--- a/indymeet/settings/storages.py
+++ b/indymeet/settings/storages.py
@@ -6,7 +6,7 @@ from storages.backends.azure_storage import AzureStorage
 
 class AzureMediaStorage(AzureStorage):
     account_name = settings.AZURE_ACCOUNT_NAME
-    account_key = settings.AZURE_STORAGE_KEY
+    account_key = settings.AZURE_ACCOUNT_KEY
     azure_container = settings.AZURE_MEDIA_CONTAINER
     expiration_secs = None
     overwrite_files = True
@@ -14,7 +14,7 @@ class AzureMediaStorage(AzureStorage):
 
 class AzureStaticStorage(AzureStorage):
     account_name = settings.AZURE_ACCOUNT_NAME
-    account_key = settings.AZURE_STORAGE_KEY
+    account_key = settings.AZURE_ACCOUNT_KEY
     azure_container = settings.AZURE_STATIC_CONTAINER
     expiration_secs = None
     overwrite_files = True

--- a/indymeet/settings/storages.py
+++ b/indymeet/settings/storages.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from django.conf import settings
 from storages.backends.azure_storage import AzureStorage
 
@@ -15,6 +17,7 @@ class AzureStaticStorage(AzureStorage):
     account_key = settings.AZURE_STORAGE_KEY
     azure_container = settings.AZURE_STATIC_CONTAINER
     expiration_secs = None
+    overwrite_files = True
 
 
 """

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "djangonaut-space",
+  "version": "1.0.0",
+  "engines": {
+    "node": "17.6.0"
+  }
+}

--- a/scripts/postbuild.sh
+++ b/scripts/postbuild.sh
@@ -1,0 +1,3 @@
+python manage.py tailwind install
+python manage.py tailwind build
+python manage.py collectstatic --noinput


### PR DESCRIPTION
This stops using collectstatic as a part of the oryx build system and uses a custom post build script.

Since tailwind requires node to compile the final css file, we need to add a package.json file and ENABLE_MULTIPLEPLATFORM_BUILD to get Oryx to install both python and node. This allows the post build script to run.

This also fixes the Azure media/static file storage issue by exposing the environment variables to actually push content there.

This will need a few new secrets configured and we may potentially need to change AZURE_CUSTOM_DOMAIN since I don't think that was ever used/tested.