### PR TITLE
revert back Blog link! can't test on Windows with new requirements

### DIFF
--- a/home/templates/home/home_page.html
+++ b/home/templates/home/home_page.html
@@ -14,6 +14,7 @@
         <a class="button-secondary text-black bg-white hover:bg-purple hover:text-white" href="{% url "session_list" %}">Sessions</a>
         <a class="button-secondary" href="{% url "event_list" %}">Events</a>
         <a class="button-secondary" href="https://github.com/djangonaut-space/pilot-program/blob/main/README.md">Program</a>
+        <a class="button-secondary" href="{% slugurl "comms" %}">Blog</a>
     </div>
 
     {% comment %} <form class="d-flex form-row">

--- a/indymeet/templates/includes/nav.html
+++ b/indymeet/templates/includes/nav.html
@@ -1,4 +1,4 @@
-{% load i18n static  %}
+{% load i18n static wagtailcore_tags %}
 <nav class="bg-white {% if 'Home' in page.title %}stars{% endif %}">
     <div class="mx-2 flex h-16 max-w-screen-xl items-center gap-8 px-1 sm:px-4 lg:px-2">
         <a class="block text-teal-600" href="/">
@@ -13,22 +13,24 @@
                         {% trans "Program Documentation" %}
                     </a>
                 </li>
-
                 <li>
                     <a class="outline-link text-gray-700 transition hover:text-ds-purple" target="_blank"  href="https://forms.gle/4vNuqQwEK6o48WqHA">
                         {% trans "Join us!" %}
                     </a>
                 </li>
-
                 <li>
                     <a class="outline-link text-gray-700 transition hover:text-ds-purple"  href="{% url 'event_list' %}">
                         {% trans "Events" %}
                     </a>
                 </li>
-
                 <li>
                     <a class="outline-link text-gray-700 transition hover:text-ds-purple"  href="{% url 'session_list' %}">
                         {% trans "Sessions" %}
+                    </a>
+                </li>
+                <li>
+                    <a class="outline-link text-gray-700 transition hover:text-ds-purple"  href="{% slugurl "comms" %}">
+                        {% trans "Blog" %}
                     </a>
                 </li>
             </ul>
@@ -89,6 +91,11 @@
                         <li class="p-2">
                             <a class="block outline-link text-gray-500 transition hover:text-ds-purple"  href="{% url 'session_list' %}">
                                 {% trans "Sessions" %}
+                            </a>
+                        </li>
+                        <li class="p-2">
+                            <a class="block outline-link text-gray-500 transition hover:text-ds-purple"  href="{% slugurl "comms" %}">
+                                {% trans "Blog" %}
                             </a>
                         </li>
                     </ul>


### PR DESCRIPTION
Weird daisy chain of errors. I'll have to add it back on my linux machine. 

Wagtail menu requires pillow-heif which has odd installation requirements on windows machine. I'm going back to @tim-schilling 's solution. 

https://wagtailmenus.readthedocs.io/en/stable/installation.html
https://pillow-heif.readthedocs.io/en/latest/installation.html#windows