### PR TITLE
Fix landing page

### DIFF
--- a/home/templates/home/home_page.html
+++ b/home/templates/home/home_page.html
@@ -10,8 +10,8 @@
     </a>
     <h1 class="p-0 text-[10vw] leading-[10vw] font-fraunces font-bold text-center">Where contributors launch</h1>
     <p class="p-3 text-xl">Ready for take-off?</p>
-    <div class="flex flex-column flex-sm-row links mt-0 mb-0">
-        <a class="button-secondary text-black bg-white hover:bg-purple hover:text-white" href="{% url "session_list" %}">Sessions</a>
+    <div class="flex flex-col md:flex-row links mt-0 mb-0">
+        <a class="button-secondary text-black bg-white hover:bg-ds-purple hover:text-white" href="{% url "session_list" %}">Sessions</a>
         <a class="button-secondary" href="{% url "event_list" %}">Events</a>
         <a class="button-secondary" href="https://github.com/djangonaut-space/pilot-program/blob/main/README.md">Program</a>
         <a class="button-secondary" href="{% slugurl "comms" %}">Blog</a>

--- a/theme/static_src/src/djangonaut-space.css
+++ b/theme/static_src/src/djangonaut-space.css
@@ -30,7 +30,7 @@
     }
 
     .button-secondary {
-        @apply inline-block rounded-[40px] px-[32px] py-[13px] text-white bg-gray-600 mx-1 hover:bg-gray-700 hover:text-white no-underline;
+        @apply inline-block rounded-[40px] px-[32px] py-[13px] text-center text-white bg-gray-600 m-1 hover:bg-gray-700 hover:text-white no-underline;
     }
 
     .outline-link {


### PR DESCRIPTION
The class on the homepage was the bootstrap one, and add also margin on top and bottom of the buttons to avoid them all being stuck together and center the text 


Screenshots 📷 
<img width="442" alt="Capture d’écran 2024-01-10 à 08 30 46" src="https://github.com/djangonaut-space/wagtail-indymeet/assets/17890338/20569312-e0a6-45c3-97c7-4b136c21e0cf">

<img width="1122" alt="Capture d’écran 2024-01-10 à 08 16 36" src="https://github.com/djangonaut-space/wagtail-indymeet/assets/17890338/933a4f07-017a-4f6e-83b8-bce6e4dadc55">

