### PR TITLE
Programatically enable the debug toolbar.

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -6,3 +6,6 @@ SECRET_KEY=<SECRETKEY>
 ENVIRONMENT='production'
 RECAPTCHA_PUBLIC_KEY='dummy_value'
 RECAPTCHA_PRIVATE_KEY='dummy_value'
+# Only set to a non-empty string value if you want it enabled
+# The toolbar should not be used in a remote environment
+ENABLE_TOOLBAR=""

--- a/indymeet/settings/base.py
+++ b/indymeet/settings/base.py
@@ -60,7 +60,6 @@ INSTALLED_APPS = [
     # azure storage
     "storages",
     # other
-    "debug_toolbar",
     "tailwind",
     "theme",
 ]
@@ -75,7 +74,6 @@ MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
     "wagtail.contrib.redirects.middleware.RedirectMiddleware",
-    "debug_toolbar.middleware.DebugToolbarMiddleware",
 ]
 
 AZURE_IP = os.environ.get("AZURE_IP", False)
@@ -220,3 +218,7 @@ PUPUT_ENTRY_MODEL = "home.models.BlogAbstract"
 MIGRATION_MODULES = {"puput": "home.puput_migrations"}
 
 TAILWIND_APP_NAME = "theme"
+
+if os.environ.get("ENABLE_TOOLBAR"):
+    INSTALLED_APPS += ["debug_toolbar"]
+    MIDDLEWARE += ["debug_toolbar.middleware.DebugToolbarMiddleware"]

--- a/indymeet/urls.py
+++ b/indymeet/urls.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import os
+
 from django.conf import settings
 from django.contrib import admin
 from django.urls import include
@@ -18,7 +20,6 @@ urlpatterns = [
     path("accounts/", include("accounts.urls")),
     path("", include("home.urls")),
     path("", include("puput.urls")),
-    path("__debug__/", include("debug_toolbar.urls")),
 ]
 
 
@@ -29,6 +30,11 @@ if settings.DEBUG:
     # Serve static and media files from development server
     urlpatterns += staticfiles_urlpatterns()
     urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+
+    if os.environ.get("ENABLE_TOOLBAR"):
+        urlpatterns += [
+            path("__debug__/", include("debug_toolbar.urls")),
+        ]
 
 urlpatterns = urlpatterns + [
     # For anything not caught by a more specific rule above, hand over to


### PR DESCRIPTION
The django debug toolbar should not be run in a production environment and should only be enabled in remove environments temporarily. It can expose sensitive information and if we're using a clone of the production data in a staging environment, it could expose prod data.

References #146