### PR TITLE
Create a README to always force the theme static dir.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
   build:
     env:
       ENVIRONMENT: 'test'
-      DJANGO_SETTINGS_MODULE: 'indymeet.settings.production'
+      DJANGO_SETTINGS_MODULE: 'indymeet.settings.test'
       HOST: "localhost"
       USER: "djangonaut"
       PASSWORD: "djangonaut"

--- a/indymeet/settings/test.py
+++ b/indymeet/settings/test.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from .production import *
+
+#    Get rid of whitenoise "No directory at" warning, as it's not helpful when running tests.
+# Related:
+# - https://github.com/evansd/whitenoise/issues/215
+# - https://github.com/evansd/whitenoise/issues/191
+# - https://github.com/evansd/whitenoise/commit/4204494d44213f7a51229de8bc224cf6d84c01eb
+WHITENOISE_AUTOREFRESH = True
+
+# Use MD5 hasher as it's much faster per:
+# https://docs.djangoproject.com/en/5.0/topics/testing/overview/#password-hashing
+PASSWORD_HASHERS = [
+    "django.contrib.auth.hashers.MD5PasswordHasher",
+]

--- a/manage.py
+++ b/manage.py
@@ -5,7 +5,12 @@ import os
 import sys
 
 if __name__ == "__main__":
-    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "indymeet.settings.dev")
+    # If we're running tests, default to the test settings file
+    default_settings = (
+        "indymeet.settings.test" if "test" in sys.argv else "indymeet.settings.dev"
+    )
+
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", default_settings)
 
     from django.core.management import execute_from_command_line
 

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -1,4 +1,5 @@
 -r requirements.txt
+-r requirements-test.txt
 pre-commit
 django-tailwind[reload]
 django-debug-toolbar

--- a/theme/static/README
+++ b/theme/static/README
@@ -1,0 +1,2 @@
+# This directory exists to silence a warning from django
+# about a directory of STATICFILES_DIRS not existing.


### PR DESCRIPTION
The production build process requires that this directory exists. Otherwise Django raises a warning in the check system.

I chose to use a README instead of .gitkeep or .gitignore since I could explain the reasoning for the file and folder.