### PR TITLE
Remove migrate from postbuild script.

### DIFF
--- a/scripts/postbuild.sh
+++ b/scripts/postbuild.sh
@@ -1,4 +1,3 @@
 python manage.py tailwind install
 python manage.py tailwind build
 python manage.py collectstatic --noinput
-python manage.py migrate


### PR DESCRIPTION
This would require us to have the database connection settings in our github repository and that doesn't sit well with me currently. Let's keep looking.