### PR TITLE
Avoid urlizing richtext fields

### DIFF
--- a/indymeet/templates/blocks/rich_text.html
+++ b/indymeet/templates/blocks/rich_text.html
@@ -1,3 +1,3 @@
 <div class="mt-3 ">
-  {{ value.text|safe|urlize }}
+  {{ value.text|safe }}
 </div>


### PR DESCRIPTION
The richtext blocks should handle formatting the links which will result in a tags. This is why we need the `|safe` template filter.