### PR TITLE
Styled webring

### DIFF
--- a/home/templates/home/home_page.html
+++ b/home/templates/home/home_page.html
@@ -10,7 +10,7 @@
     </a>
     <h1 class="p-0 text-[10vw] leading-[10vw] font-fraunces font-bold text-center">Where contributors launch</h1>
     <p class="p-3 text-xl">Ready for take-off?</p>
-    <div class="flex flex-wrap flex-row links justify-center w-full md:w-1/3 gap-2">
+    <div class="flex flex-wrap flex-row links justify-center w-full lg:w-2/5 gap-2">
         <a class="button-secondary text-black bg-white hover:bg-ds-purple hover:text-white" href="{% url "session_list" %}">Sessions</a>
         <a class="button-secondary" href="{% url "event_list" %}">Events</a>
         <a class="button-secondary" href="https://github.com/djangonaut-space/program/blob/main/README.md">Program</a>

--- a/home/templates/home/home_page.html
+++ b/home/templates/home/home_page.html
@@ -24,10 +24,14 @@
         <button type="submit" class="btn btn-outline-primary">Register</button>
     </form> {% endcomment %}
 </main>
-<footer class="landing-page-footer text-base text-white">
+<footer class="landing-page-footer text-base text-white items-center mt-2 md:mt-0 flex flex-col md:flex-row justify-evenly space-y-3 md:space-y-0">
     <span class="design-credits">Djangonaut Space. Designed by <a class='text-white' href='https://hope-adoli.netlify.app/'>Hope Adoli</a></span>
     <a class='text-white' href="https://github.com/djangonaut-space/program/blob/main/CODE_OF_CONDUCT.md">Code of Conduct</a>
-    <div class="p-3 flex gap-2 social-links">
+     <div class="scale-75 md:scale-50 -my-4 -mx-10">
+        <webring-css site="https://djangonaut.space"></webring-css>
+        <script src="https://djangowebring.com/static/webring.js"></script>
+    </div>
+    <div class="flex gap-2 social-links">
         <a class="outline-link twitter" href="https://twitter.com/djangonautspace" target="_blank" aria-label="Twitter">
             <i class="fa-brands fa-twitter" aria-hidden="true"></i>
         </a>
@@ -48,9 +52,6 @@
         </a>
     </div>
 </footer>
-<div class="z-10">
-    <webring-css site="https://djangonaut.space"></webring-css>
-    <script src="https://djangowebring.com/static/webring.js"></script>
-</div>
-<div id="particules-js" class="absolute w-[100%] h-[100%]"></div>
+
+<div id="particules-js" class="absolute w-[100%] h-[100%] "></div>
 {% endblock content %}

--- a/home/templates/home/home_page.html
+++ b/home/templates/home/home_page.html
@@ -27,8 +27,8 @@
 <footer class="landing-page-footer text-base text-white items-center mt-2 md:mt-0 flex flex-col md:flex-row justify-evenly space-y-3 md:space-y-0">
     <span class="design-credits">Djangonaut Space. Designed by <a class='text-white' href='https://hope-adoli.netlify.app/'>Hope Adoli</a></span>
     <a class='text-white' href="https://github.com/djangonaut-space/program/blob/main/CODE_OF_CONDUCT.md">Code of Conduct</a>
-     <div class="scale-75 md:scale-50 -my-4 -mx-10">
-        <webring-css site="https://djangonaut.space"></webring-css>
+     <div>
+        <webring-css site="https://djangonaut.space" class="-my-5 -mx-8 scale-75 md:scale-50"></webring-css>
         <script src="https://djangowebring.com/static/webring.js"></script>
     </div>
     <div class="flex gap-2 social-links">

--- a/theme/static_src/src/djangonaut-space.css
+++ b/theme/static_src/src/djangonaut-space.css
@@ -115,11 +115,11 @@
 }
 
 .landing-page-footer {
-    display: flex;
+
     align-items: center;
-    flex-wrap: wrap;
-    justify-content: space-between;
-    margin: 0 2em;
+
+
+
     padding: 10px 0;
     width: calc(100% - 4em);
     color: white;

--- a/theme/static_src/src/djangonaut-space.css
+++ b/theme/static_src/src/djangonaut-space.css
@@ -89,14 +89,14 @@
     color: white;
 }
 
-.landing-page::after {
+.landing-page-overlay::after {
     content: "";
     position: absolute;
     left: 0;
     top: 0;
     bottom: 0;
     right: 0;
-    background: linear-gradient(180deg, rgba(14, 16, 11, 0.00) 0%, rgba(14, 16, 11, 0.89) 55.29%);
+    background: linear-gradient(180deg, rgba(14, 16, 11, 0.00) 0%, rgba(14, 16, 11, 0.89) 50%);
     width: 100%;
     height: 100%;
     z-index: -1;


### PR DESCRIPTION
I updated the homepage to better style the web-ring

* the container of the links (sessions, events..) is bigger
* the webring is resized to fit better inside the footer
* the black background is moved to fit the entire page

This is how the homepage looks now
<img width="1552" alt="Screenshot 2025-04-15 alle 15 29 45" src="https://github.com/user-attachments/assets/c1d97cea-7a86-40e9-8d0a-12ae02af2718" />

This is how the footer looks on mobile
![Screenshot 2025-04-15 alle 15 32 23](https://github.com/user-attachments/assets/1049bb0e-d3ff-4ac7-94e0-da88e9249f69)
