### PR TITLE
Add newsletter subscription links to the site.

### DIFF
--- a/home/templates/home/home_page.html
+++ b/home/templates/home/home_page.html
@@ -26,7 +26,12 @@
 </main>
 <footer class="landing-page-footer text-base text-white items-center mt-2 md:mt-0 flex flex-col md:flex-row justify-evenly space-y-3 md:space-y-0">
     <span class="design-credits">Djangonaut Space. Designed by <a class='text-white' href='https://hope-adoli.netlify.app/'>Hope Adoli</a></span>
-    <a class='text-white' href="https://github.com/djangonaut-space/program/blob/main/CODE_OF_CONDUCT.md">Code of Conduct</a>
+    <a class='text-white' href="https://github.com/djangonaut-space/program/blob/main/CODE_OF_CONDUCT.md">
+      Code of Conduct
+    </a>
+    <a class='text-white' target="_blank" href="https://buttondown.com/djangonaut-space">
+      Newsletter
+    </a>
      <div>
         <webring-css site="https://djangonaut.space" class="-my-5 -mx-8 scale-75 md:scale-50"></webring-css>
         <script src="https://djangowebring.com/static/webring.js"></script>

--- a/indymeet/templates/includes/footer.html
+++ b/indymeet/templates/includes/footer.html
@@ -4,6 +4,9 @@
     <div class="flex-auto mx-1">
         <a href="mailto:contact@djangonaut.space">Contact Us</a>
     </div>
+    <div class="flex-auto mx-1">
+        <a  target="_blank" href="https://buttondown.com/djangonaut-space">Newsletter</a>
+    </div>
     <div class="flex grow gap-4 mx-1">
         <div class="h-14 rounded-full bg-gradient-to-t">
         <a class="outline-link twitter " href="https://twitter.com/djangonautspace" target="_blank" aria-label="Twitter">

--- a/indymeet/templates/includes/nav.html
+++ b/indymeet/templates/includes/nav.html
@@ -34,6 +34,15 @@
         {% if not user.is_authenticated %}
         <div class="flex items-center gap-4">
             <div class="sm:flex sm:gap-4">
+                <a
+                    class="block rounded-md bg-primary px-5 py-2.5 text-sm font-medium text-white transition hover:bg-gray-300 hover:text-ds-purple cursor-pointer"
+                    href="https://buttondown.com/djangonaut-space"
+                    target="_blank"
+                >
+                  {% trans "Subscribe" %}
+                </a>
+                {% comment %}
+                Remove these until we get a sign-up path working. For now, redirect to the mailing list subscription
                 {% if "login" not in request.path %}
                 <a class="hidden rounded-md bg-gray-100 px-5 py-2.5 text-sm font-medium text-ds-purple transition hover:bg-gray-300 sm:block cursor-pointer" href="{% url 'login' %}?next_page={{request.path}}">
                   {% trans "Login" %}
@@ -44,6 +53,7 @@
                   {% trans "Sign Up" %}
                 </a>
                 {% endif %}
+                {% endcomment %}
           </div>
           {% else %}
            <div class="relative hidden md:block" x-data="{ showDropdown: false }">


### PR DESCRIPTION
This removes the login and sign up buttons from the website. These aren't usable right now and we want to route people to the newsletter for now.

- Changes the navbar upper right corner button to Subscribe
- Adds a footer link to "Newsletter" to landing page
- Adds a footer link to "Newsletter" to non-landing pages (I don't know what to call these)

#### Changed parts
<img width="1904" height="136" alt="Screenshot from 2025-07-21 16-36-58" src="https://github.com/user-attachments/assets/770e4d2b-a0c8-4e73-85eb-37904e0b17cc" />
<img width="1904" height="136" alt="Screenshot from 2025-07-21 16-37-11" src="https://github.com/user-attachments/assets/8ce5248a-568f-4857-89ed-3d75e46180dd" />
<img width="975" height="197" alt="Screenshot from 2025-07-21 16-37-35" src="https://github.com/user-attachments/assets/25fab6d3-da1a-404e-9ffb-b5752375602f" />

#### Full page views
<img width="1899" height="957" alt="Screenshot from 2025-07-21 16-37-43" src="https://github.com/user-attachments/assets/8d7f104a-75d2-4d8b-9920-040d4c3e1500" />
<img width="1899" height="957" alt="Screenshot from 2025-07-21 16-37-48" src="https://github.com/user-attachments/assets/62e7d5c7-cda0-4285-b070-24aeece9c28b" />
