### PR TITLE
Style fix ups

### DIFF
--- a/indymeet/templates/includes/resend_confirmation_email_button.html
+++ b/indymeet/templates/includes/resend_confirmation_email_button.html
@@ -1,5 +1,5 @@
 {% load i18n %}
 <form action="{% url 'resend_email_confirmation' %}"  method="POST" class="inline-block sm:ml-4 sm:float-right">
    {% csrf_token %}
-   <button type="submit">{% translate "Resend Email" %}</button>
+   <button class="action-button" type="submit">{% translate "Resend Email" %}</button>
 </form>

--- a/indymeet/templates/registration/profile.html
+++ b/indymeet/templates/registration/profile.html
@@ -41,11 +41,11 @@
                     </tr>
                     <tr class="border-b-2">
                         <td class="pt-4 pb-1 pr-6">{% translate "Email confirmed" %}</td>
-                        <td class="pt-4 pb-1 pr-6">
+                        <td class="pt-4 pb-1 pr-6 flex items-center">
                             {%  if user.profile.email_confirmed %}
-                            <i class="fa-solid fa-check"></i> {% translate "Yes" %}
+                            <span><i class="fa-solid fa-check"></i> {% translate "Yes" %}</span>
                             {%  else %}
-                            <i class="fa-solid fa-x"></i> {% translate "No" %}
+                            <span><i class="fa-solid fa-x"></i> {% translate "No" %}</span>
                             {% include 'includes/resend_confirmation_email_button.html' %}
                             {% endif %}
                         </td>


### PR DESCRIPTION
This does several things to improve the styles and appearance of the application

- Removes CDN version of tailwind (this was reseting styles unexpectedly and the source of many headaches)
- Fixes the excerpt rendering as text rather than html
- Adjusts the styles and colors of buttons to be standard `class="action-button"` for the standard purple button now
- Links now appear as links with underlines (this is inline with accessibility standards for navigational elements)
- Made the create survey wider

#### All footer links are now purple with underlines
<img width="1600" height="89" alt="Screenshot from 2025-09-30 15-59-59" src="https://github.com/user-attachments/assets/83d05a06-3ef4-48f7-8698-ebc5f61d4d1c" />

#### Update password (new button)
<img width="580" height="611" alt="Screenshot from 2025-09-30 15-59-27" src="https://github.com/user-attachments/assets/23b91252-0e9b-4cd8-bb98-efbd0ae590cc" />

#### Update profile (new button, inputs have borders (!), cancel is a link)
<img width="976" height="834" alt="Screenshot from 2025-09-30 15-59-17" src="https://github.com/user-attachments/assets/50c8a55e-c628-4ecc-b859-fe0fd25b193e" />

#### View profile (update is a link rather than a button)
<img width="534" height="593" alt="Screenshot from 2025-09-30 15-59-03" src="https://github.com/user-attachments/assets/40c3868f-6163-4e29-a1d6-6621b82d507b" />

#### Blog return icon is now purple to match the text
<img width="321" height="142" alt="Screenshot from 2025-09-30 15-58-51" src="https://github.com/user-attachments/assets/f9ea6003-63df-4741-a83a-1cfa5228ad53" />

#### The updated list item appearance when viewing our blog (header is only purple on hover)
<img width="1176" height="404" alt="Screenshot from 2025-09-30 15-58-22" src="https://github.com/user-attachments/assets/57d8fa04-c8eb-49e7-a947-435b051fc745" />

References #500, #501