### PR TITLE
Utilize Zizmor for GitHub Action security hardening

### DIFF
--- a/.claude/shared.md
+++ b/.claude/shared.md
@@ -95,6 +95,13 @@ uv run pytest -m playwright --headed  # See browser
 - Write tests alongside all new features
 - Generate high-level architecture/design documentation in `docs/` folder
 - Write helpful docstrings that provide context
+- Run zizmor security checks on GitHub Actions workflows when modifying `.github/` directory
+
+### GitHub Actions Security
+- **Run zizmor locally** when modifying workflow files: `uvx zizmor .github/workflows/`
+- Zizmor checks for security issues in GitHub Actions workflows
+- The zizmor workflow runs automatically on PRs that modify `.github/` directory
+- Address any security findings before committing workflow changes
 
 ### Testing Requirements
 - **Always run tests** before considering work complete
@@ -314,6 +321,10 @@ uv run pytest path/to/test.py    # Specific test file
 uv run python manage.py tailwind install
 uv run python manage.py tailwind start
 uv run python manage.py tailwind build   # Production build
+
+# GitHub Actions Security
+uvx zizmor .github/workflows/           # Check all workflows
+uvx zizmor .github/workflows/tests.yml  # Check specific workflow
 
 # Production/staging locally
 uv run python manage.py runserver --settings=indymeet.settings.production

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,24 +1,16 @@
 version: 2
 updates:
   # Maintain dependencies for Python
-  - package-ecosystem: "pip"
-    directory: "requirements/"
+  - package-ecosystem: "uv"
+    directory: "/"
     schedule:
-      interval: "daily"
-    groups:
-      dependencies:
-        patterns:
-          - "*" # Update all dependencies"
+      interval: "weekly"
 
   # Maintain dependencies for NPM / tailwind generation
   - package-ecosystem: "npm"
     directory: "theme/static_src/"
     schedule:
-      interval: "weekly"
-    groups:
-      dependencies:
-        patterns:
-          - "*" # Update all dependencies"
+      interval: "monthly"
 
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -15,14 +15,17 @@ concurrency:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Cloning repo
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Push to dokku
-        uses: dokku/github-action@v1.8.0
+        uses: dokku/github-action@33d50129fe718c3f907c8b29ea58776ed3cf8221 # v1.8.0
         env:
           SSH_PRIVATE_KEY: ${{ secrets.DEPLOY_DOKKU_SSH_PRIVATE_KEY }}
         with:

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -15,14 +15,17 @@ concurrency:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Cloning repo
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Push to dokku
-        uses: dokku/github-action@v1.8.0
+        uses: dokku/github-action@33d50129fe718c3f907c8b29ea58776ed3cf8221 # v1.8.0
         env:
           SSH_PRIVATE_KEY: ${{ secrets.DEPLOY_DOKKU_SSH_PRIVATE_KEY }}
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,9 +21,11 @@ jobs:
       RECAPTCHA_PUBLIC_KEY: "dummy_value"
       RECAPTCHA_PRIVATE_KEY: "dummy_value"
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     services:
       pg:
-        image: postgres
+        image: postgres:17
         ports:
           - 5432:5432
         env:
@@ -32,6 +34,8 @@ jobs:
           POSTGRES_DB: "djangonaut-space"
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - name: Set up Python version
         uses: actions/setup-python@v6
@@ -39,7 +43,7 @@ jobs:
           python-version: '3.11'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,29 @@
+name: GitHub Actions Security Analysis with zizmor 🌈
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - '.github/**'
+  pull_request:
+    paths:
+      - '.github/**'
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: Run zizmor 🌈
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read # only needed for private repos
+      actions: read # only needed for private repos
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor 🌈
+        uses: zizmorcore/zizmor-action@e673c3917a1aef3c65c972347ed84ccd013ecda4 # v0.2.0


### PR DESCRIPTION
This switches to using hashes for the versions. This is a little more difficult to maintain, but dependabot will catch when there's a new version and Claude can more easily update the files.