### PR TITLE
Set a max length limit on survey text fields to 700 characters.

### DIFF
--- a/home/constants.py
+++ b/home/constants.py
@@ -1,6 +1,6 @@
 DATE_INPUT_FORMAT = ["%Y-%m-%d", "%m/%d/%Y", "%m/%d/%y", "%d/%m/%y", "%d/%m/%Y"]
 
 SURVEY_FIELD_VALIDATORS = {
-    "max_length": {"email": 150, "text": 250, "url": 250},
-    "min_length": {"text_area": 100, "text": 3},
+    "max_length": {"email": 250, "text": 700, "text_area": 700, "url": 250},
+    "min_length": {"text_area": 1, "text": 1},
 }

--- a/home/forms.py
+++ b/home/forms.py
@@ -108,7 +108,10 @@ class BaseSurveyForm(forms.Form):
                     validators=[
                         MinLengthValidator(
                             SURVEY_FIELD_VALIDATORS["min_length"]["text_area"]
-                        )
+                        ),
+                        MaxLengthValidator(
+                            SURVEY_FIELD_VALIDATORS["max_length"]["text_area"]
+                        ),
                     ],
                 )
             elif question.type_field == TypeField.RATING:


### PR DESCRIPTION
This reduces the min length down to 1.

Closes #303