### PR TITLE
Update survey form timestamp on edit

### DIFF
--- a/home/forms.py
+++ b/home/forms.py
@@ -5,6 +5,7 @@ from django import forms
 from django.core.validators import MaxLengthValidator
 from django.core.validators import MinLengthValidator
 from django.db import transaction, IntegrityError
+from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
 from home.constants import DATE_INPUT_FORMAT
@@ -220,6 +221,8 @@ class EditUserSurveyResponseForm(BaseSurveyForm):
     @transaction.atomic
     def save(self):
         cleaned_data = super().clean()
+        self.user_survey_response.updated_at = timezone.now()
+        self.user_survey_response.save(update_fields=["updated_at"])
 
         question_responses = [
             UserQuestionResponse(

--- a/home/tests/test_forms.py
+++ b/home/tests/test_forms.py
@@ -245,3 +245,31 @@ class EditUserSurveyResponseFormTests(TestCase):
             form.errors["__all__"],
             ["You are no longer able to edit this."],
         )
+
+    def test_edit_form_updates_timestamp(self):
+        """Test that editing a survey response updates the updated_at timestamp."""
+        # Create a session with active application period
+        SessionFactory.create_active(self.simple_survey)
+
+        # Get the original timestamp
+        original_timestamp = self.user_survey_response.updated_at
+
+        # Edit the response
+        form = EditUserSurveyResponseForm(
+            instance=self.user_survey_response,
+            data={
+                f"field_survey_{self.simple_survey_question.id}": "Updated response",
+            },
+        )
+        self.assertTrue(form.is_valid())
+        form.save()
+
+        # Refresh from database
+        self.user_survey_response.refresh_from_db()
+
+        # Verify timestamp was updated
+        self.assertGreater(
+            self.user_survey_response.updated_at,
+            original_timestamp,
+            "updated_at timestamp should be updated after editing",
+        )


### PR DESCRIPTION
Update the UserSurveyResponse.updated_at timestamp when a response is edited via EditUserSurveyResponseForm. This ensures the timestamp accurately reflects the last modification time.

Add test coverage to verify timestamp is updated on edit.