### PR TITLE
Improve survey form UI and navigation

### DIFF
--- a/home/templates/home/surveys/detail.html
+++ b/home/templates/home/surveys/detail.html
@@ -4,10 +4,29 @@
 {% block content %}
 <main class="section">
     <div class="section-container">
+        <nav class="mb-4 text-sm" aria-label="breadcrumb">
+            <ol class="flex items-center gap-2">
+                <li><a href="{% url 'profile' %}" class="text-blue-600 hover:text-blue-800 hover:underline">{% translate "Profile" %}</a></li>
+                <li class="text-gray-400">/</li>
+                <li class="text-gray-600">Survey / {{ survey.name }}</li>
+            </ol>
+        </nav>
+
         <h1 class="text-center text-5xl">{{ survey.name }}</h1>
         <p class="max-w-md mx-auto mt-4 text-center text-gray-500">
             {{ survey.description|linebreaks|urlize }}
         </p>
+
+        <div class="mt-8 mb-4 flex gap-4">
+            {% if is_editable %}
+            <a href="{% url 'edit_user_survey_response' survey.slug %}" class="px-6 py-3 bg-ds-purple text-white text-center flex-1 rounded hover:bg-purple-500">
+                {% trans "Edit Response" %}
+            </a>
+            {% endif %}
+            <a href="{% url 'profile' %}" class="px-6 py-3 border border-gray-300 rounded hover:bg-gray-50 text-center flex-1">
+                {% trans "Back to Profile" %}
+            </a>
+        </div>
 
         <div class="space-y-6 mt-6">
             {% for response in responses %}
@@ -21,17 +40,6 @@
                     </div>
                 </div>
             {% endfor %}
-        </div>
-
-        <div class="mt-8 flex gap-4">
-            {% if is_editable %}
-            <a href="{% url 'edit_user_survey_response' survey.slug %}" class="action-button block text-center flex-1">
-                {% trans "Edit Response" %}
-            </a>
-            {% endif %}
-            <a href="{% url 'profile' %}" class="px-6 py-3 border border-gray-300 rounded hover:bg-gray-50 block text-center flex-1">
-                {% trans "Back to Profile" %}
-            </a>
         </div>
     </div>
 </main>

--- a/home/templates/home/surveys/form.html
+++ b/home/templates/home/surveys/form.html
@@ -4,6 +4,19 @@
 {% block content %}
 <main class="section">
     <div class="section-container">
+        <nav class="mb-4 text-sm" aria-label="breadcrumb">
+            <ol class="flex items-center gap-2">
+                <li><a href="{% url 'profile' %}" class="text-blue-600 hover:text-blue-800 hover:underline">{% translate "Profile" %}</a></li>
+                <li class="text-gray-400">/ Survey /</li>
+                {% if is_editing %}
+                  <li><a href="{% url 'user_survey_response' slug=survey.slug %}" class="text-blue-600 hover:text-blue-800 hover:underline">{{ survey.name }}</a></li>
+                  <li class="text-gray-400">/</li>
+                {% else %}
+                  <li class="text-gray-400">/ {{ survey.name }} /</li>
+                {% endif %}
+                <li class="text-gray-600">{% if is_editing %}{% trans "Edit" %}{% else %}{% trans "Create" %}{% endif %}</li>
+            </ol>
+        </nav>
         <h1 class="text-center text-5xl">{{ survey.name }}</h1>
         <p class="max-w-md mx-auto mt-4 text-center text-gray-500">
             {{ survey.description|linebreaks|urlize }}
@@ -14,6 +27,11 @@
           </div>
         {% endif %}
         <form method="post">
+            {% if is_editing %}
+                <button type="submit" class="action-button mt-8 mb-4 block w-full">
+                    {% trans "Submit" %}
+                </button>
+            {% endif %}
             {% csrf_token %}
             {% for field in form %}
                 <div class="p-8 mt-6 mb-0 space-y-4 rounded-lg shadow-md border border-gray-200 bg-white">

--- a/home/tests/test_user_survey_response_form_views.py
+++ b/home/tests/test_user_survey_response_form_views.py
@@ -49,6 +49,23 @@ class CreateUserSurveyResponseFormViewTests(TestCase):
         self.assertContains(response, "Test Survey")
         self.assertContains(response, "This is a description of the survey!")
 
+    def test_template_shows_create_mode(self):
+        """Test that template renders correctly in create mode."""
+        self.client.force_login(self.user)
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+        content = response.content.decode()
+        # Should show "Create" in breadcrumb
+        self.assertIn(">Create</li>", content)
+        # Should NOT show "Edit" in breadcrumb
+        self.assertNotIn(">Edit</li>", content)
+        # In create mode, the breadcrumb should show survey name as plain text, not a link
+        self.assertNotIn(
+            f'<a href="{reverse("user_survey_response", kwargs={"slug": self.survey.slug})}"',
+            content,
+        )
+
     def test_error_message(self):
         self.client.force_login(self.user)
         response = self.client.post(self.url, {})
@@ -164,6 +181,23 @@ class EditUserSurveyResponseViewTests(TestCase):
         self.assertContains(response, "Test Survey")
         self.assertContains(response, "How are you?")
         self.assertContains(response, "Good")
+
+    def test_template_shows_edit_mode(self):
+        """Test that template renders correctly in edit mode."""
+        self.client.force_login(self.user)
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+        content = response.content.decode()
+        # Should show "Edit" in breadcrumb
+        self.assertIn(">Edit</li>", content)
+        # Should NOT show "Create" in breadcrumb
+        self.assertNotIn(">Create</li>", content)
+        # Should have link back to survey response view in breadcrumb
+        self.assertIn(
+            f'href="{reverse("user_survey_response", kwargs={"slug": self.survey.slug})}"',
+            content,
+        )
 
     def test_edit_survey_response_success(self):
         # Create a session with active application period

--- a/home/views.py
+++ b/home/views.py
@@ -135,6 +135,7 @@ class CreateUserSurveyResponseFormView(
 
     def get_context_data(self, **kwargs):
         kwargs["survey"] = self.get_object()
+        kwargs["is_editing"] = False
         return super().get_context_data(**kwargs)
 
     def post(self, request, *args, **kwargs):
@@ -202,6 +203,7 @@ class EditUserSurveyResponseView(LoginRequiredMixin, ModelFormMixin, DetailView)
 
     def get_context_data(self, **kwargs):
         kwargs["survey"] = self.object.survey
+        kwargs["is_editing"] = True
         return super().get_context_data(**kwargs)
 
     def post(self, request, *args, **kwargs):

--- a/indymeet/templates/registration/profile.html
+++ b/indymeet/templates/registration/profile.html
@@ -80,9 +80,22 @@
                             {% endif %}
                         </td>
                     </tr>
+                    <tr class="border-b-2">
+                        <td class="pt-4 pb-1 pr-6">{% translate "Weekly Availability" %}</td>
+                        <td class="pt-4 pb-1 pr-6">
+                            {% if user.availability.slots %}
+                            <i class="fa-solid fa-check"></i> {% translate "Set" %} ({{ user.availability.slots|length }} {% translate "slots" %})
+                            {% else %}
+                            <i class="fa-solid fa-x"></i> {% translate "Not set" %}
+                            {% endif %}
+                        </td>
+                    </tr>
                 </tbody>
             </table>
-            <a href="{% url 'update_user' %}">{% translate "Update" %}</a>
+            <div class="flex gap-4">
+                <a href="{% url 'update_user' %}" class="inline-block px-4 py-2 border border-gray-300 rounded hover:bg-gray-50">{% translate "Update Profile" %}</a>
+                <a href="{% url 'availability' %}" class="inline-block px-4 py-2 border border-gray-300 rounded hover:bg-gray-50">{% translate "Set Availability" %}</a>
+            </div>
           </div>
         </div>
 
@@ -110,7 +123,7 @@
                                 {% translate "View" %}
                             </a>
                             {% if response.is_editable %}
-                            <a href="{% url 'edit_user_survey_response' slug=response.survey.slug %}" class="px-4 py-2 text-sm bg-blue-600 text-white rounded hover:bg-blue-700">
+                            <a href="{% url 'edit_user_survey_response' slug=response.survey.slug %}" class="px-4 py-2 text-sm bg-ds-purple text-white rounded hover:bg-purple-500">
                                 {% translate "Edit" %}
                             </a>
                             {% endif %}

--- a/theme/static_src/src/djangonaut-space.css
+++ b/theme/static_src/src/djangonaut-space.css
@@ -40,7 +40,7 @@
 
 @layer components {
     .action-button {
-        @apply bg-ds-purple hover:bg-purple-500 text-white px-4 py-2 rounded-lg font-medium transition-colors cursor-pointer;
+        @apply bg-ds-purple hover:bg-purple-500 text-white px-4 py-2 rounded font-medium transition-colors cursor-pointer;
     }
 }
 


### PR DESCRIPTION
Add breadcrumb navigation to survey detail and form pages for better user orientation and easier navigation back to profile.

Move action buttons to the top of survey detail page for better visibility and add a submit button at the top of edit forms for improved UX when dealing with long surveys.

Update styling for consistency:
- Change Edit button to use bg-ds-purple (matching site theme)
- Update action-button class to use standard rounded corners

Add is_editing context variable to distinguish between create and edit modes in templates, with corresponding test coverage.

<img width="999" height="446" alt="Screenshot from 2025-10-24 15-37-25" src="https://github.com/user-attachments/assets/1dec4193-8893-4a8f-8482-a10e012592e3" />
<img width="999" height="446" alt="Screenshot from 2025-10-24 15-37-16" src="https://github.com/user-attachments/assets/ec2ff26a-0f31-42da-9871-e252ad42eb43" />
