### PR TITLE
 add color coding to profile page Yes/No indicators

### DIFF
--- a/indymeet/templates/registration/profile.html
+++ b/indymeet/templates/registration/profile.html
@@ -56,7 +56,7 @@
                             {%  if user.profile.receiving_program_updates %}
                             <span class="text-green-600"><i class="fa-solid fa-check"></i> {% translate "Yes" %}</span>
                             {%  else %}
-                            <span class="text-red-600"><i class="fa-solid fa-x"></i> {% translate "No" %}</span>
+                            <span class="text-gray-500"><i class="fa-solid fa-x"></i> {% translate "No" %}</span>
                             {% endif %}
                         </td>
                     </tr>
@@ -66,7 +66,7 @@
                             {%  if user.profile.receiving_event_updates %}
                             <span class="text-green-600"><i class="fa-solid fa-check"></i> {% translate "Yes" %}</span>
                             {%  else %}
-                            <span class="text-red-600"><i class="fa-solid fa-x"></i> {% translate "No" %}</span>
+                            <span class="text-gray-500"><i class="fa-solid fa-x"></i> {% translate "No" %}</span>
                             {% endif %}
                         </td>
                     </tr>
@@ -76,7 +76,7 @@
                         {%  if user.profile.receiving_newsletter %}
                             <span class="text-green-600"><i class="fa-solid fa-check"></i> {% translate "Yes" %}</span>
                             {%  else %}
-                            <span class="text-red-600"><i class="fa-solid fa-x"></i> {% translate "No" %}</span>
+                            <span class="text-gray-500"><i class="fa-solid fa-x"></i> {% translate "No" %}</span>
                             {% endif %}
                         </td>
                     </tr>


### PR DESCRIPTION
- Colorize Yes values in green (text-green-600)
- Colorize No values in red (text-red-600)
- Applied to Email confirmed, Program updates, Event updates, and Newsletter fields