### PR TITLE
Disallow hosts with nginx rather than Django.

### DIFF
--- a/nginx.conf.d/djangonaut-space-block-invalid-hosts.conf
+++ b/nginx.conf.d/djangonaut-space-block-invalid-hosts.conf
@@ -1,0 +1,8 @@
+# Create/update this with:
+# sudo -u dokku nano /home/dokku/djangonaut-space/nginx.conf.d/djangonaut-space-block-invalid-hosts
+# dokku proxy:build-config djangonaut-space
+
+# Block requests with invalid Host headers
+if ($host !~* ^(djangonaut\.space)$) {
+    return 444;
+}

--- a/nginx.conf.d/staging-block-invalid-hosts.conf
+++ b/nginx.conf.d/staging-block-invalid-hosts.conf
@@ -1,0 +1,8 @@
+# Create/update this with:
+# sudo -u dokku nano /home/dokku/staging/nginx.conf.d/staging-block-invalid-hosts
+# dokku proxy:build-config staging
+
+# Block requests with invalid Host headers
+if ($host !~* ^(staging\.djangonaut\.space)$) {
+    return 444;
+}


### PR DESCRIPTION
This is more efficient, though it requires manual changes with dokku. The instructions are in the files themselves.

Fixes #556 