### PR TITLE
Limit the width of the alert container

### DIFF
--- a/indymeet/templates/base.html
+++ b/indymeet/templates/base.html
@@ -93,9 +93,9 @@
         <script src="{% static "js/alpine.min.js" %}" defer></script>
         <script src="{% static "js/htmx.min.js" %}"></script>
         {% wagtailuserbar %}
-        {% include 'includes/messages.html' %}
         <div class="{% if not blog_page %}container flex justify-center mb-auto mx-auto max-w-screen-xl {% endif %}">
             <div class="{% if not blog_page %}w-3/4{% endif %}">
+            {% include 'includes/messages.html' %}
             {% block content %}
                 {# other page stuff goes here #}
             {% endblock %}

--- a/indymeet/templates/includes/nav.html
+++ b/indymeet/templates/includes/nav.html
@@ -74,7 +74,7 @@
                   <img class="w-8 h-8 rounded-full" src={%  if user.profile.bio_image %}"{{ user.profile.bio_image }}"{% else %}"{% static 'img/favicon.png' %}"{% endif %} alt="Profile photo">
                 </button>
                 <div x-cloak x-show="showDropdown">
-                  <ul class="py-2 absolute right-0 py-2 mt-2 bg-gray-100 rounded-md shadow-xl w-44" aria-labelledby="user-menu-button">
+                  <ul class="py-2 absolute right-0 py-2 mt-2 bg-gray-100 rounded-md shadow-xl w-44 z-50" aria-labelledby="user-menu-button">
                     <li class="p-2">
                       <a href="{% url 'profile' %}" class="block outline-link text-gray-500 transition hover:text-ds-purple">
                           {% trans "Profile" %}
@@ -115,7 +115,7 @@
                     </svg>
                 </button>
                 <div x-cloak x-show="showDropdown">
-                    <ul class="absolute right-0 py-2 mt-2 bg-gray-100 rounded-md shadow-xl w-44">
+                    <ul class="absolute right-0 py-2 mt-2 bg-gray-100 rounded-md shadow-xl w-44 z-50">
                         <li class="p-2">
                             <a class="block outline-link text-gray-500 transition hover:text-ds-purple" target="_blank" href="https://github.com/djangonaut-space/program/blob/main/README.md">
                                 {% trans "Program Documentation" %}


### PR DESCRIPTION
This was going across the whole page and rendering on top of the profile menu dropdown. This narrows it and increases the z-index on the profile dropdown.
<img width="1841" height="318" alt="Screenshot from 2025-11-24 15-54-12" src="https://github.com/user-attachments/assets/8f822b7a-12b6-443b-a8f2-2e98d7ffa541" />
