### PR TITLE
Show the applicant's project preferences in team formation.

### DIFF
--- a/home/templates/admin/team_formation.html
+++ b/home/templates/admin/team_formation.html
@@ -150,6 +150,7 @@
                                 {% trans "Rank" %}
                             </th>
                             <th>{% trans "Team" %}</th>
+                            <th>{% trans "Project Preferences" %}</th>
                             <th class="sortable {% if sort_by == 'previous_application_count' %}sorted-{{ sort_order }}{% endif %}"
                                 data-sort="previous_application_count">
                                 {% trans "Prev Apps" %}
@@ -177,6 +178,15 @@
                                     Waitlisted
                                 {% else %}
                                     <span class="badge badge-unassigned">{% trans "Unassigned" %}</span>
+                                {% endif %}
+                            </td>
+                            <td>
+                                {% if applicant.project_preferences %}
+                                    {% for project in applicant.project_preferences|dictsort:"name" %}
+                                        {{ project.name }}<br>
+                                    {% endfor %}
+                                {% else %}
+                                    <em>{% trans "Any" %}</em>
                                 {% endif %}
                             </td>
                             <td>{{ applicant.previous_application_count }}</td>


### PR DESCRIPTION
This includes a test that should confirm this doesn't increase the query count moving forward.

<img width="1367" height="438" alt="Screenshot from 2025-11-24 16-34-38" src="https://github.com/user-attachments/assets/bd2c18f2-b7c6-45f4-9895-731879096a40" />
