### PR TITLE
Convert the session title link on My Sessions to team page.

### DIFF
--- a/home/models/session.py
+++ b/home/models/session.py
@@ -329,6 +329,10 @@ class SessionMembership(models.Model):
     )
     objects = models.Manager.from_queryset(SessionMembershipQuerySet)()
 
+    def is_organizer(self) -> bool:
+        """Check if this membership has the Organizer role."""
+        return self.role == self.ORGANIZER
+
 
 class WaitlistQuerySet(models.QuerySet):
     """Custom QuerySet for Waitlist model."""

--- a/home/templates/home/session/user_sessions.html
+++ b/home/templates/home/session/user_sessions.html
@@ -24,9 +24,13 @@
             <div class="flex justify-between items-start mb-4">
               <div>
                 <h2 class="text-2xl font-extrabold mb-2">
-                  <a href="{% url 'session_detail' slug=membership.session.slug %}">
+                  {% if membership.team and not membership.is_organizer %}
+                    <a href="{% url 'team_detail' session_slug=membership.session.slug pk=membership.team.pk %}">
+                      {{ membership.session.title }}
+                    </a>
+                  {% else %}
                     {{ membership.session.title }}
-                  </a>
+                  {% endif %}
                 </h2>
                 <div class="flex gap-2 mb-2">
                   {% if membership.session.status == 'current' %}
@@ -87,7 +91,7 @@
               {% endif %}
             </dl>
 
-            {% if membership.role == "Organizer" %}
+            {% if membership.is_organizer %}
             <div class="mt-4">
               <h4>All Teams</h4>
               <ul>

--- a/home/tests/test_models.py
+++ b/home/tests/test_models.py
@@ -9,12 +9,13 @@ from home.factories import (
     ProjectFactory,
     QuestionFactory,
     SessionFactory,
+    SessionMembershipFactory,
     SurveyFactory,
     TeamFactory,
     UserQuestionResponseFactory,
     UserSurveyResponseFactory,
 )
-from home.models import TypeField
+from home.models import SessionMembership, TypeField
 
 
 class SessionTests(TestCase):
@@ -472,6 +473,17 @@ class UserSurveyResponseTests(TestCase):
         response.send_updated_notification()
         self.assertEqual(len(mail.outbox), 1)
         self.assertIn(response.get_full_url(), mail.outbox[0].body)
+
+
+class SessionMembershipTests(TestCase):
+    """Tests for SessionMembership model."""
+
+    def test_is_organizer(self):
+        """Test is_organizer() returns True only for Organizer role."""
+        organizer = SessionMembershipFactory.create(role=SessionMembership.ORGANIZER)
+        captain = SessionMembershipFactory.create(role=SessionMembership.CAPTAIN)
+        self.assertTrue(organizer.is_organizer())
+        self.assertFalse(captain.is_organizer())
 
 
 class TeamTests(TestCase):


### PR DESCRIPTION
The organizers will have links for the individual teams below and the Session details page isn't helpful to the members here.