### PR TITLE
Support users deleting their accounts.

### DIFF
--- a/accounts/forms.py
+++ b/accounts/forms.py
@@ -135,3 +135,39 @@ class UserAvailabilityForm(forms.ModelForm):
     class Meta:
         model = UserAvailability
         fields = ("slots",)
+
+
+class DeleteAccountForm(forms.Form):
+    """Form for confirming permanent account deletion with password verification."""
+
+    password = forms.CharField(
+        required=True,
+        label="Confirm your password",
+        help_text="Enter your password to confirm account deletion.",
+        widget=forms.PasswordInput(
+            attrs={
+                "class": "w-full px-3 py-2 border border-gray-300 rounded-md "
+                "focus:outline-none focus:ring-2 focus:ring-red-500",
+                "autocomplete": "current-password",
+            }
+        ),
+    )
+
+    def __init__(self, *args, user=None, **kwargs):
+        """Initialize form with user instance for validation."""
+        super().__init__(*args, **kwargs)
+        self.user = user
+
+    def clean_password(self):
+        """Validate password against user's actual password."""
+        password = self.cleaned_data.get("password")
+
+        if not self.user:
+            raise forms.ValidationError("User not found.")
+
+        if not self.user.check_password(password):
+            raise forms.ValidationError(
+                "Incorrect password. Account deletion cancelled."
+            )
+
+        return password

--- a/accounts/tasks.py
+++ b/accounts/tasks.py
@@ -1,0 +1,30 @@
+"""Background task for permanent user account deletion."""
+
+from django.contrib.auth import get_user_model
+from django_tasks import task
+
+from home import email
+
+User = get_user_model()
+
+
+@task()
+def delete_user_account(user_id: int) -> None:
+    """
+    Permanently delete user account and all related data via CASCADE.
+
+    Email confirmation is best-effort - deletion proceeds even if email fails.
+    """
+    try:
+        user = User.objects.get(pk=user_id)
+    except User.DoesNotExist:
+        pass
+    else:
+        user_email = user.email
+        user_name = user.get_full_name() or user.username
+        user.delete()
+        email.send(
+            email_template="account_deleted_confirmation",
+            recipient_list=[user_email],
+            context={"user_name": user_name},
+        )

--- a/accounts/tests/test_delete_account_form.py
+++ b/accounts/tests/test_delete_account_form.py
@@ -1,0 +1,35 @@
+"""Tests for account deletion form."""
+
+from django.test import TestCase
+
+from accounts.factories import UserFactory
+from accounts.forms import DeleteAccountForm
+
+
+class DeleteAccountFormTests(TestCase):
+    """Tests for DeleteAccountForm."""
+
+    def setUp(self):
+        self.user = UserFactory.create(username="testuser")
+        self.user.set_password("testpassword123")
+        self.user.save()
+
+    def test_valid_form_with_correct_password(self):
+        form = DeleteAccountForm({"password": "testpassword123"}, user=self.user)
+        self.assertTrue(form.is_valid())
+
+    def test_invalid_form_with_incorrect_password(self):
+        form = DeleteAccountForm({"password": "wrongpassword"}, user=self.user)
+        self.assertFalse(form.is_valid())
+        self.assertIn("password", form.errors)
+        self.assertIn("Incorrect password", form.errors["password"][0])
+
+    def test_requires_password(self):
+        form = DeleteAccountForm({}, user=self.user)
+        self.assertFalse(form.is_valid())
+        self.assertIn("password", form.errors)
+
+    def test_empty_password_is_invalid(self):
+        form = DeleteAccountForm({"password": ""}, user=self.user)
+        self.assertFalse(form.is_valid())
+        self.assertIn("password", form.errors)

--- a/accounts/tests/test_delete_account_task.py
+++ b/accounts/tests/test_delete_account_task.py
@@ -1,0 +1,56 @@
+"""Tests for account deletion background task."""
+
+from unittest.mock import patch
+
+from django.test import TestCase, override_settings
+
+from accounts.factories import UserFactory
+from accounts.models import CustomUser, UserProfile
+from accounts.tasks import delete_user_account
+from home.factories import SessionFactory, SessionMembershipFactory
+from home.models import SessionMembership, Waitlist
+
+
+class DeleteUserAccountTaskTests(TestCase):
+    """Tests for the delete_user_account task."""
+
+    def setUp(self):
+        self.user = UserFactory.create(
+            username="testuser",
+            email="test@example.com",
+            first_name="Test",
+            last_name="User",
+        )
+        self.user_id = self.user.id
+
+        session = SessionFactory.create()
+        SessionMembershipFactory.create(
+            user=self.user, session=session, role=SessionMembership.DJANGONAUT
+        )
+
+        Waitlist.objects.create(user=self.user, session=session)
+
+    @patch("accounts.tasks.email.send")
+    def test_deletes_user_and_sends_confirmation_email(self, mock_send):
+        self.assertTrue(CustomUser.objects.filter(pk=self.user_id).exists())
+
+        delete_user_account.call(user_id=self.user_id)
+
+        mock_send.assert_called_once()
+        call_kwargs = mock_send.call_args[1]
+        self.assertEqual(call_kwargs["email_template"], "account_deleted_confirmation")
+        self.assertEqual(call_kwargs["recipient_list"], ["test@example.com"])
+        self.assertEqual(call_kwargs["context"]["user_name"], "Test User")
+
+        self.assertFalse(CustomUser.objects.filter(pk=self.user_id).exists())
+
+    @patch("accounts.tasks.email.send")
+    def test_deletion_proceeds_even_if_email_fails(self, mock_send):
+        mock_send.side_effect = Exception("Email service down")
+
+        self.assertTrue(CustomUser.objects.filter(pk=self.user_id).exists())
+
+        with self.assertRaises(Exception):
+            delete_user_account.call(user_id=self.user_id)
+
+        self.assertFalse(CustomUser.objects.filter(pk=self.user_id).exists())

--- a/accounts/tests/test_delete_account_views.py
+++ b/accounts/tests/test_delete_account_views.py
@@ -1,0 +1,85 @@
+"""Tests for account deletion views."""
+
+from unittest.mock import patch
+
+from django.test import Client, TestCase
+from django.urls import reverse
+
+from accounts.factories import UserFactory
+from home.factories import SessionFactory, SessionMembershipFactory
+from home.models import SessionMembership
+
+
+class DeleteAccountConfirmationViewTests(TestCase):
+    """Tests for DeleteAccountView GET requests (confirmation page)."""
+
+    def setUp(self):
+        self.client = Client()
+        self.user = UserFactory.create(username="testuser")
+        self.url = reverse("delete_account")
+
+    def test_requires_login(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("/accounts/login", response.url)
+
+    def test_displays_confirmation_page(self):
+        self.client.force_login(self.user)
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Delete Account")
+        self.assertContains(response, "This action cannot be undone")
+        self.assertContains(response, "password")
+
+    def test_shows_related_data_counts(self):
+        session = SessionFactory.create()
+        SessionMembershipFactory.create(
+            user=self.user, session=session, role=SessionMembership.DJANGONAUT
+        )
+
+        self.client.force_login(self.user)
+        response = self.client.get(self.url)
+
+        self.assertContains(response, "session memberships")
+        self.assertContains(response, "(1)")
+
+
+class DeleteAccountViewTests(TestCase):
+    """Tests for DeleteAccountView POST requests (deletion processing)."""
+
+    def setUp(self):
+        self.client = Client()
+        self.user = UserFactory.create(username="testuser", email="test@example.com")
+        self.user.set_password("testpassword123")
+        self.user.save()
+        self.url = reverse("delete_account")
+
+    def test_requires_login(self):
+        response = self.client.post(self.url)
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("/accounts/login", response.url)
+
+    def test_blocks_staff_users(self):
+        staff_user = UserFactory.create(username="staff", is_staff=True)
+        self.client.force_login(staff_user)
+
+        response = self.client.get(self.url, follow=True)
+
+        self.assertRedirects(response, reverse("profile"))
+        self.assertContains(response, "Staff accounts cannot be deleted")
+
+    @patch("accounts.views.delete_user_account")
+    def test_successful_deletion_enqueues_task_and_logs_out(self, mock_task):
+        user_id = self.user.id
+
+        self.client.force_login(self.user)
+        response = self.client.post(
+            self.url,
+            {"password": "testpassword123"},
+            follow=True,
+        )
+
+        mock_task.enqueue.assert_called_once_with(user_id=user_id)
+        self.assertNotIn("_auth_user_id", self.client.session)
+        self.assertContains(response, "account deletion has been initiated")

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -4,6 +4,7 @@ from django.urls import path
 
 from .views import ActivateAccountView
 from .views import CustomPasswordResetView
+from .views import DeleteAccountView
 from .views import profile
 from .views import ResendConfirmationEmailView
 from .views import SignUpView
@@ -45,5 +46,10 @@ urlpatterns = [
         "availability/",
         UpdateAvailabilityView.as_view(),
         name="availability",
+    ),
+    path(
+        "delete/",
+        DeleteAccountView.as_view(),
+        name="delete_account",
     ),
 ]

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -2,27 +2,34 @@
 from django.contrib import messages
 from django.contrib.auth import get_user_model
 from django.contrib.auth import login
+from django.contrib.auth import logout
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.mixins import LoginRequiredMixin
+from django.contrib.auth.mixins import UserPassesTestMixin
 from django.contrib.auth.views import PasswordResetView
+from django.http import HttpRequest
+from django.http import HttpResponse
 from django.shortcuts import redirect
 from django.shortcuts import render
-from django.urls import reverse
+from django.urls import reverse, reverse_lazy
 from django.utils.encoding import force_bytes
 from django.utils.encoding import force_str
 from django.utils.http import urlsafe_base64_decode
 from django.utils.http import urlsafe_base64_encode
 from django.views import View
 from django.views.generic.edit import CreateView
+from django.views.generic.edit import FormView
 from django.views.generic.edit import UpdateView
 
 from home.email import send
 
 from .forms import CustomUserChangeForm
 from .forms import CustomUserCreationForm
+from .forms import DeleteAccountForm
 from .forms import EmailSubscriptionsChangeForm
 from .forms import UserAvailabilityForm
 from .models import UserAvailability
+from .tasks import delete_user_account
 from .tokens import account_activation_token
 
 
@@ -47,9 +54,7 @@ class ActivateAccountView(View):
             return redirect("profile")
         else:
             # invalid link
-            messages.add_message(
-                request, messages.ERROR, "Your confirmation link is invalid."
-            )
+            messages.error(request, "Your confirmation link is invalid.")
             return redirect("signup")
 
 
@@ -220,3 +225,59 @@ class UpdateAvailabilityView(LoginRequiredMixin, UpdateView):
             "Your availability has been updated successfully.",
         )
         return reverse("profile")
+
+
+class DeleteAccountView(LoginRequiredMixin, UserPassesTestMixin, FormView):
+    """Display account deletion confirmation page and process deletion requests."""
+
+    template_name = "registration/delete_account_confirmation.html"
+    form_class = DeleteAccountForm
+    success_url = reverse_lazy("login")
+
+    def test_func(self):
+        """Check that the user is not a staff member."""
+        return not self.request.user.is_staff
+
+    def handle_no_permission(self):
+        """Redirect to profile with error message when staff tries to delete account."""
+        # If user is not authenticated, let LoginRequiredMixin handle it
+        if not self.request.user.is_authenticated:
+            return super().handle_no_permission()
+
+        # User is authenticated but is staff
+        messages.error(
+            self.request,
+            "Staff accounts cannot be deleted. Please contact an administrator "
+            "if you need to remove your account.",
+        )
+        return redirect("profile")
+
+    def get_form_kwargs(self):
+        """Pass the current user to the form for validation."""
+        kwargs = super().get_form_kwargs()
+        kwargs["user"] = self.request.user
+        return kwargs
+
+    def get_context_data(self, **kwargs):
+        """Add deletion statistics to context."""
+        return super().get_context_data(
+            **kwargs,
+            session_memberships_count=self.request.user.session_memberships.count(),
+            survey_responses_count=self.request.user.usersurveyresponse_set.count(),
+        )
+
+    def form_valid(self, form):
+        """Process account deletion and enqueue background task."""
+        user_id = self.request.user.id
+
+        delete_user_account.enqueue(user_id=user_id)
+
+        logout(self.request)
+
+        messages.info(
+            self.request,
+            "Your account deletion has been initiated. You will receive a "
+            "confirmation email once the process is complete. Thank you for "
+            "being part of Djangonaut Space.",
+        )
+        return redirect("login")

--- a/home/templates/email/account_deleted_confirmation/body.html
+++ b/home/templates/email/account_deleted_confirmation/body.html
@@ -1,0 +1,47 @@
+{% extends "email/base.html" %}
+
+{% block preheader %}Account Deleted - Djangonaut Space{% endblock preheader %}
+
+{% block greeting %}
+  <p style="font-family: Helvetica, sans-serif; font-size: 16px; font-weight: normal; margin: 0; margin-bottom: 16px;">Hello {{ user_name }},</p>
+{% endblock greeting %}
+
+{% block before_cta %}
+  <p style="font-family: Helvetica, sans-serif; font-size: 16px; font-weight: normal; margin: 0; margin-bottom: 16px;">
+    This email confirms that your Djangonaut Space account has been permanently deleted as requested.
+  </p>
+
+  <p style="font-family: Helvetica, sans-serif; font-size: 16px; font-weight: normal; margin: 0; margin-bottom: 16px;">
+    All your personal data and associated records have been removed from our systems:
+  </p>
+
+  <ul style="font-family: Helvetica, sans-serif; font-size: 16px; margin: 0; margin-bottom: 16px; padding-left: 20px;">
+    <li style="margin-bottom: 8px;">Profile information</li>
+    <li style="margin-bottom: 8px;">Session memberships</li>
+    <li style="margin-bottom: 8px;">Survey responses</li>
+    <li style="margin-bottom: 8px;">Project preferences</li>
+    <li style="margin-bottom: 8px;">Availability data</li>
+    <li style="margin-bottom: 8px;">All related records</li>
+  </ul>
+
+  <p style="font-family: Helvetica, sans-serif; font-size: 16px; font-weight: normal; margin: 0; margin-bottom: 16px;">
+    <strong>This action is permanent and cannot be reversed.</strong>
+  </p>
+{% endblock before_cta %}
+
+{% block cta_button %}{% endblock cta_button %}
+
+{% block after_cta %}
+  <p style="font-family: Helvetica, sans-serif; font-size: 16px; font-weight: normal; margin: 0; margin-bottom: 16px;">
+    We're sorry to see you go! Thank you for being part of the Djangonaut Space community.
+  </p>
+
+  <p style="font-family: Helvetica, sans-serif; font-size: 16px; font-weight: normal; margin: 0; margin-bottom: 16px;">
+    If you did not request this deletion or have any concerns, please contact us immediately at <a href="mailto:hello@djangonaut.space" style="color: #5c0287;">hello@djangonaut.space</a>.
+  </p>
+
+  <p style="font-family: Helvetica, sans-serif; font-size: 16px; font-weight: normal; margin: 0;">
+    Best regards,<br>
+    The Djangonaut Space Team
+  </p>
+{% endblock after_cta %}

--- a/home/templates/email/account_deleted_confirmation/body.txt
+++ b/home/templates/email/account_deleted_confirmation/body.txt
@@ -1,0 +1,20 @@
+Hello {{ user_name }},
+
+This email confirms that your Djangonaut Space account has been permanently deleted as requested.
+
+All your personal data and associated records have been removed from our systems:
+- Profile information
+- Session memberships
+- Survey responses
+- Project preferences
+- Availability data
+- All related records
+
+This action is permanent and cannot be reversed.
+
+We're sorry to see you go! Thank you for being part of the Djangonaut Space community.
+
+If you did not request this deletion or have any concerns, please contact us immediately at hello@djangonaut.space.
+
+Best regards,
+The Djangonaut Space Team

--- a/home/templates/email/account_deleted_confirmation/subject.txt
+++ b/home/templates/email/account_deleted_confirmation/subject.txt
@@ -1,0 +1,1 @@
+Your Djangonaut Space account has been deleted

--- a/indymeet/templates/registration/delete_account_confirmation.html
+++ b/indymeet/templates/registration/delete_account_confirmation.html
@@ -1,0 +1,103 @@
+{% extends "base.html" %}
+{% load i18n wagtailcore_tags static %}
+
+{% block title %}{% translate "Delete Account | Djangonaut Space" %}{% endblock %}
+{% block meta_title %}{% translate "Delete Account | Djangonaut Space" %}{% endblock %}
+
+{% block extra_css %}
+<link rel="stylesheet" href="{% static 'css/registration.css' %}">
+{% endblock extra_css %}
+
+{% block content %}
+<main class="section my-3 mx-5">
+    <div class="section-container max-w-3xl">
+        <h1 class="text-5xl mb-6 text-red-600">{% translate "Delete Account" %}</h1>
+
+        <!-- Red warning banner -->
+        <div class="bg-red-50 border-l-4 border-red-500 p-4 mb-6">
+            <div class="flex">
+                <div class="flex-shrink-0">
+                    <i class="fa-solid fa-triangle-exclamation text-red-500 text-2xl"></i>
+                </div>
+                <div class="ml-3">
+                    <h3 class="text-lg font-medium text-red-800">
+                        {% translate "Warning: This action cannot be undone" %}
+                    </h3>
+                    <p class="mt-2 text-red-700">
+                        {% translate "Deleting your account is permanent and irreversible. All your data will be completely removed from our systems." %}
+                    </p>
+                </div>
+            </div>
+        </div>
+
+        <!-- What will be deleted -->
+        <div class="bg-white shadow rounded-lg p-6 mb-6">
+            <h2 class="text-2xl font-semibold mb-4">{% translate "What will be deleted" %}</h2>
+            <ul class="space-y-2 mb-4">
+                <li class="flex items-start">
+                    <i class="fa-solid fa-xmark text-red-500 mt-1 mr-2"></i>
+                    <span>{% translate "Your profile information" %}</span>
+                </li>
+                {% if session_memberships_count > 0 %}
+                <li class="flex items-start">
+                    <i class="fa-solid fa-xmark text-red-500 mt-1 mr-2"></i>
+                    <span>{% translate "Your session memberships" %} ({{ session_memberships_count }})</span>
+                </li>
+                {% endif %}
+                <li class="flex items-start">
+                    <i class="fa-solid fa-xmark text-red-500 mt-1 mr-2"></i>
+                    <span>{% translate "Your survey responses and applications" %} ({{ survey_responses_count }})</span>
+                </li>
+            </ul>
+        </div>
+
+        <form method="post" class="bg-gray-50 rounded-lg p-6">
+            {% csrf_token %}
+
+            {% if form.non_field_errors %}
+            <div class="mb-4 bg-red-50 border border-red-200 rounded-md p-3">
+                <ul class="text-red-700 text-sm">
+                    {% for error in form.non_field_errors %}
+                    <li>{{ error }}</li>
+                    {% endfor %}
+                </ul>
+            </div>
+            {% endif %}
+
+            <div class="mb-6">
+                <label for="{{ form.password.id_for_label }}" class="block text-sm font-medium text-gray-700 mb-2">
+                    {{ form.password.label }} <span class="text-red-600">*</span>
+                </label>
+                {{ form.password }}
+                {% if form.password.errors %}
+                <div class="mt-1 text-sm text-red-600">
+                    {% for error in form.password.errors %}
+                    <p>{{ error }}</p>
+                    {% endfor %}
+                </div>
+                {% endif %}
+                {% if form.password.help_text %}
+                <p class="mt-1 text-sm text-gray-500">
+                    {{ form.password.help_text }}
+                </p>
+                {% endif %}
+            </div>
+
+            <div class="flex gap-4">
+                <button
+                    type="submit"
+                    class="px-6 py-3 bg-red-600 text-white font-semibold rounded-md hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500"
+                >
+                    {% translate "Delete My Account Permanently" %}
+                </button>
+                <a
+                    href="{% url 'profile' %}"
+                    class="px-6 py-3 bg-gray-200 text-gray-800 font-semibold rounded-md hover:bg-gray-300 focus:outline-none focus:ring-2 focus:ring-gray-400"
+                >
+                    {% translate "Cancel" %}
+                </a>
+            </div>
+        </form>
+    </div>
+</main>
+{% endblock content %}

--- a/indymeet/templates/registration/profile.html
+++ b/indymeet/templates/registration/profile.html
@@ -142,6 +142,19 @@
           </div>
         </div>
         {% endif %}
+
+        <div class="row mt-2 pb-4">
+          <div class="col pt-4 border-t border-gray-200">
+              <h3 class="text-xl font-semibold text-gray-900 mb-2">{% translate "Danger Zone" %}</h3>
+              <p class="text-sm text-gray-600 mb-4">
+                  {% translate "Permanently delete your account and all associated data. This action cannot be undone." %}
+              </p>
+              <a href="{% url 'delete_account' %}"
+                 class="inline-block px-4 py-2 bg-red-100 text-red-700 border border-red-300 rounded hover:bg-red-200">
+                  {% translate "Delete Account" %}
+              </a>
+          </div>
+        </div>
     </div>
 </main>
 {% endblock content %}


### PR DESCRIPTION
This requires the user to re-enter their password to delete their account. This operation will be irreversible.

Users who were marked as is_staff (had access to django or wagtail admin) will not be able to be deleted. We'll need to manually handle those flows.

<img width="1247" height="864" alt="Screenshot from 2025-11-25 15-07-50" src="https://github.com/user-attachments/assets/32099169-508d-49df-8d12-49a7d88d7c20" />
<img width="1247" height="864" alt="Screenshot from 2025-11-25 15-07-59" src="https://github.com/user-attachments/assets/f1c44b1c-5c56-404a-bc27-b28c708d8951" />
<img width="1247" height="864" alt="Screenshot from 2025-11-25 15-08-11" src="https://github.com/user-attachments/assets/0cf4f52a-3bc7-4b11-88e2-7367b671c7c2" />
<img width="662" height="704" alt="Screenshot from 2025-11-25 15-09-14" src="https://github.com/user-attachments/assets/a70924f5-2f42-42ce-bbc0-a1d66f7b60cb" />
