### PR TITLE
Support allocating teams based on selection rank and score.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ mediafiles/*
 media/*
 .env
 dist/
+.coverage
 
 staticfiles/*
 mediafiles/*

--- a/home/team_allocation.py
+++ b/home/team_allocation.py
@@ -1,0 +1,484 @@
+"""
+Team allocation algorithm for assigning Djangonauts to teams.
+
+This module implements a bounded search algorithm that:
+- Allocates Djangonauts to teams with Navigators and Captains already assigned
+- Ensures availability overlap requirements are met:
+  * 5+ hours overlap among ALL team members (navigators + all djangonauts)
+  * 3+ hours overlap between captain and each individual djangonaut
+- Respects project preferences
+- Optimizes for allocating the highest-ranked applicants
+- Prefers forming complete teams of 3 Djangonauts
+
+IMPORTANT - Cumulative Overlap Constraint:
+    The 5-hour navigator overlap requirement applies to ALL members of the team
+    together. As each djangonaut is added, the common overlapping time window
+    may shrink. The algorithm checks that adding a new djangonaut maintains at
+    least 5 hours of overlap across ALL navigators and ALL djangonauts (both
+    existing and new).
+
+    Example:
+        Navigator: Mon 00:00-06:00
+        Add Django1 (Mon 00:00-06:00) → Overlap = 6 hours ✓
+        Add Django2 (Mon 00:00-05:00) → Overlap (nav+d1+d2) = 5 hours ✓
+        Try Django3 (Mon 00:00-04:00) → Overlap (nav+d1+d2+d3) = 4 hours ✗
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from django.db.models import Prefetch
+
+from home.availability import calculate_overlap
+from home.models import SessionMembership, Team, UserSurveyResponse, ProjectPreference
+
+if TYPE_CHECKING:
+    from accounts.models import CustomUser
+    from home.models import Project, Session
+
+
+@dataclass
+class AllocationCandidate:
+    """Represents a Djangonaut candidate for team allocation."""
+
+    user: CustomUser
+    selection_rank: int
+    score: int | None
+    response: UserSurveyResponse
+    project_preferences: list[Project]
+
+
+@dataclass
+class TeamSlot:
+    """Represents a team with available slots for Djangonauts."""
+
+    team: Team
+    navigators: list[CustomUser]
+    captain: CustomUser | None
+    max_djangonauts: int = 3
+    current_djangonauts: list[CustomUser] | None = None
+
+    def __post_init__(self):
+        """Initialize current_djangonauts list if not provided."""
+        if self.current_djangonauts is None:
+            self.current_djangonauts = []
+
+    @property
+    def available_slots(self) -> int:
+        """Get number of available slots on this team."""
+        return self.max_djangonauts - len(self.current_djangonauts)
+
+    @property
+    def is_full(self) -> bool:
+        """Check if team has reached maximum Djangonauts."""
+        return len(self.current_djangonauts) >= self.max_djangonauts
+
+    def can_add_djangonaut(self, candidate: AllocationCandidate) -> bool:
+        """
+        Check if a candidate can be added to this team.
+
+        Validates:
+        - Team has available slots
+        - Navigator availability overlap (5+ hours)
+        - Captain availability overlap (3+ hours)
+        - Project preferences match
+
+        Args:
+            candidate: The candidate to check
+
+        Returns:
+            True if candidate can be added, False otherwise
+        """
+        if self.is_full:
+            return False
+        if not self._matches_project_preference(candidate):
+            return False
+        if not self._has_sufficient_navigator_overlap(candidate):
+            return False
+        if self.captain and not self._has_sufficient_captain_overlap(candidate):
+            return False
+        return True
+
+    def _matches_project_preference(self, candidate: AllocationCandidate) -> bool:
+        """
+        Check if candidate's project preferences match this team's project.
+
+        If candidate has no preferences, they match any project.
+        If candidate has preferences, team's project must be in their list.
+
+        Args:
+            candidate: The candidate to check
+
+        Returns:
+            True if preferences match, False otherwise
+        """
+        if not candidate.project_preferences:
+            return True
+
+        return self.team.project in candidate.project_preferences
+
+    def _has_sufficient_navigator_overlap(self, candidate: AllocationCandidate) -> bool:
+        """
+        Check if adding candidate maintains 5+ hours overlap for entire team.
+
+        This checks that ALL navigators + ALL current djangonauts + new candidate
+        have at least 5 hours of overlapping availability. This ensures the whole
+        team can meet together for navigator meetings.
+
+        Args:
+            candidate: The candidate to check
+
+        Returns:
+            True if overlap >= 5 hours, False otherwise
+        """
+        all_participants = self.navigators + self.current_djangonauts + [candidate.user]
+        _, hours = calculate_overlap(all_participants)
+        return hours >= Team.MIN_NAVIGATOR_MEETING_HOURS
+
+    def _has_sufficient_captain_overlap(self, candidate: AllocationCandidate) -> bool:
+        """
+        Check if candidate has 3+ hours overlap with team captain.
+
+        Args:
+            candidate: The candidate to check
+
+        Returns:
+            True if overlap >= 3 hours, False otherwise
+        """
+        _, hours = calculate_overlap([self.captain, candidate.user])
+        return hours >= Team.MIN_CAPTAIN_OVERLAP_HOURS
+
+    def add_djangonaut(self, candidate: AllocationCandidate) -> None:
+        """
+        Add a Djangonaut to this team.
+
+        Args:
+            candidate: The candidate to add
+        """
+        self.current_djangonauts.append(candidate.user)
+
+    def remove_last_djangonaut(self) -> None:
+        """Remove the most recently added Djangonaut from this team."""
+        if self.current_djangonauts:
+            self.current_djangonauts.pop()
+
+    def copy(self) -> TeamSlot:
+        """Create a deep copy of this TeamSlot."""
+        return TeamSlot(
+            team=self.team,
+            navigators=self.navigators[:],
+            captain=self.captain,
+            max_djangonauts=self.max_djangonauts,
+            current_djangonauts=self.current_djangonauts[:],
+        )
+
+
+@dataclass
+class AllocationState:
+    """Represents the current state of team allocation."""
+
+    teams: list[TeamSlot]
+    allocated_candidates: list[tuple[AllocationCandidate, TeamSlot]]
+    unallocated_candidates: list[AllocationCandidate]
+
+    def copy(self) -> AllocationState:
+        """Create a deep copy of this allocation state."""
+        return AllocationState(
+            teams=[team.copy() for team in self.teams],
+            allocated_candidates=self.allocated_candidates[:],
+            unallocated_candidates=self.unallocated_candidates[:],
+        )
+
+    def add_candidate(
+        self, team_slot: TeamSlot, candidate: AllocationCandidate
+    ) -> AllocationState:
+        new_state = self.copy()
+        team = next(
+            _slot for _slot in new_state.teams if _slot.team.id == team_slot.team.id
+        )
+        team.add_djangonaut(candidate)
+        new_state.allocated_candidates.append((candidate, team))
+        return new_state
+
+    def get_score(self) -> tuple[int, int, int]:
+        """
+        Calculate a score for this allocation state.
+
+        Returns tuple of (num_allocated, num_complete_teams, sum_of_ranks).
+        Higher is better for comparisons. We use negative sum_of_ranks because
+        lower selection_rank values are better.
+
+        Returns:
+            Tuple of (number allocated, number of complete teams, negative sum of ranks)
+        """
+        num_allocated = len(self.allocated_candidates)
+        num_complete_teams = sum(1 for team in self.teams if team.is_full)
+
+        sum_of_ranks = sum(
+            candidate.selection_rank for candidate, _ in self.allocated_candidates
+        )
+
+        return (num_allocated, num_complete_teams, -sum_of_ranks)
+
+
+def get_allocation_candidates(
+    session: Session, max_rank: int
+) -> list[AllocationCandidate]:
+    """
+    Get all eligible candidates for team allocation.
+
+    Filters to:
+    - Users who applied to the session
+    - Not already assigned to a team
+    - Have selection_rank <= max_rank (lower is better, 0=best)
+
+    Sorted by:
+    - selection_rank ASC (lower is better)
+    - score DESC (higher is better)
+
+    Args:
+        session: The session to get candidates for
+        max_rank: Maximum selection rank to include
+
+    Returns:
+        List of AllocationCandidate instances sorted by priority
+    """
+    if not session.application_survey_id:
+        return []
+
+    responses = (
+        UserSurveyResponse.objects.filter(survey=session.application_survey)
+        .select_related("user")
+        .prefetch_related(
+            Prefetch(
+                "user__project_preferences",
+                queryset=ProjectPreference.objects.for_session(session).select_related(
+                    "project"
+                ),
+                to_attr="prefetched_project_preferences",
+            )
+        )
+        .exclude(
+            user__session_memberships__session=session,
+            user__session_memberships__role=SessionMembership.DJANGONAUT,
+        )
+        .filter(
+            selection_rank__lte=max_rank,
+        )
+        .order_by("selection_rank", "-score")
+    )
+
+    candidates = []
+    for response in responses:
+        candidates.append(
+            AllocationCandidate(
+                user=response.user,
+                selection_rank=response.selection_rank,
+                score=response.score,
+                response=response,
+                project_preferences=[
+                    pref.project
+                    for pref in response.user.prefetched_project_preferences
+                ],
+            )
+        )
+
+    return candidates
+
+
+def get_team_slots(session: Session) -> list[TeamSlot]:
+    """
+    Get all teams with available slots for Djangonauts.
+
+    Args:
+        session: The session to get teams for
+
+    Returns:
+        List of TeamSlot instances representing teams with capacity
+    """
+    teams = session.teams.all()
+
+    team_slots = []
+    for team in teams:
+        navigators = [
+            membership.user
+            for membership in team.session_memberships.navigators().select_related(
+                "user__availability"
+            )
+        ]
+
+        captain = (
+            team.session_memberships.captains()
+            .select_related("user__availability")
+            .first()
+        )
+        if captain:
+            captain = captain.user
+
+        current_djangonauts = [
+            membership.user
+            for membership in team.session_memberships.djangonauts().select_related(
+                "user__availability"
+            )
+        ]
+
+        if len(current_djangonauts) < 3:
+            team_slots.append(
+                TeamSlot(
+                    team=team,
+                    navigators=navigators,
+                    captain=captain,
+                    max_djangonauts=3,
+                    current_djangonauts=current_djangonauts,
+                )
+            )
+
+    return team_slots
+
+
+class _TeamAllocationSearcher:
+    """Helper class for searching for the best session member allocations."""
+
+    def __init__(
+        self, candidates: list[AllocationCandidate], initial_state: AllocationState
+    ):
+        """
+        Initialize the searcher.
+
+        Args:
+            candidates: List of candidates to allocate
+            initial_state: Initial allocation state
+        """
+        self.candidates = candidates
+        self.best_state = initial_state.copy()
+        self.best_score = self.best_state.get_score()
+
+    def search(self, state: AllocationState, candidate_index: int) -> None:
+        """
+        Recursive search to allocate candidates.
+
+        Args:
+            state: Current allocation state
+            candidate_index: Index of next candidate to consider
+        """
+        if candidate_index >= len(self.candidates):
+            current_score = state.get_score()
+            if current_score > self.best_score:
+                self.best_score = current_score
+                self.best_state = state.copy()
+            return
+
+        candidate = self.candidates[candidate_index]
+
+        allocated = False
+        for team in state.teams:
+            if not team.can_add_djangonaut(candidate):
+                continue
+            allocated = True
+            new_state = state.add_candidate(team, candidate)
+            # Look at the next candidate for this branch of teams
+            self.search(new_state, candidate_index + 1)
+
+        if not allocated:
+            # If this particular candidate wasn't able to be assigned to
+            # a team, move onto the next one regardless
+            self.search(state, candidate_index + 1)
+
+
+def allocate_teams_bounded_search(session: Session) -> AllocationState:
+    """
+    Allocate Djangonauts to teams using bounded search with two-phase allocation.
+
+    Phase 1: Allocates candidates with selection_rank 0-2
+    Phase 2: If teams are not full, allocates candidates with selection_rank 3
+
+    Uses a decision tree with branch-and-bound to explore allocation possibilities.
+    Prunes branches that cannot improve on the current best solution.
+
+    Args:
+        session: The session to allocate teams for
+
+    Returns:
+        Best AllocationState found
+    """
+    # Phase 1: Try to fill teams with candidates ranked 0-2
+    candidates = get_allocation_candidates(session, max_rank=2)
+    teams = get_team_slots(session)
+
+    initial_state = AllocationState(
+        teams=teams, allocated_candidates=[], unallocated_candidates=candidates
+    )
+    if not candidates or not teams:
+        return initial_state
+
+    # Run phase 1 search
+    searcher = _TeamAllocationSearcher(candidates, initial_state)
+    searcher.search(initial_state, 0)
+    best_state = searcher.best_state
+
+    # Phase 2: If any teams still have space, try rank 3 candidates
+    has_available_slots = any(team.available_slots > 0 for team in best_state.teams)
+
+    if has_available_slots:
+        # Get rank 3 candidates (not already allocated in phase 1)
+        rank3_candidates = get_allocation_candidates(session, max_rank=3)
+
+        # Filter out candidates already allocated in phase 1
+        allocated_users = {
+            candidate.user.id for candidate, _ in best_state.allocated_candidates
+        }
+        rank3_only = [
+            c
+            for c in rank3_candidates
+            if c.user.id not in allocated_users and c.selection_rank == 3
+        ]
+
+        if rank3_only:
+            # Start phase 2 with the state from phase 1
+            phase2_initial = AllocationState(
+                teams=[team.copy() for team in best_state.teams],
+                allocated_candidates=list(best_state.allocated_candidates),
+                unallocated_candidates=rank3_only,
+            )
+
+            # Run phase 2 search
+            phase2_searcher = _TeamAllocationSearcher(rank3_only, phase2_initial)
+            phase2_searcher.search(phase2_initial, 0)
+            best_state = phase2_searcher.best_state
+
+    return best_state
+
+
+def apply_allocation(allocation: AllocationState, session: Session) -> dict[str, int]:
+    """
+    Apply an allocation state to the database.
+
+    Creates SessionMembership records for allocated Djangonauts.
+
+    Args:
+        allocation: The allocation state to apply
+        session: The session to apply allocations to
+
+    Returns:
+        Dictionary with statistics about the allocation
+    """
+    members = [
+        SessionMembership(
+            user=candidate.user,
+            session=session,
+            team=team_slot.team,
+            role=SessionMembership.DJANGONAUT,
+        )
+        for candidate, team_slot in allocation.allocated_candidates
+    ]
+    SessionMembership.objects.bulk_create(
+        members,
+        ignore_conflicts=True,
+    )
+    return {
+        "created": len(members),
+        "complete_teams": sum(1 for team in allocation.teams if team.is_full),
+        "total_teams": len(allocation.teams),
+    }

--- a/home/tests/test_team_allocation.py
+++ b/home/tests/test_team_allocation.py
@@ -1,0 +1,1017 @@
+"""Tests for team allocation algorithm."""
+
+from django.test import TestCase
+
+from accounts.factories import UserAvailabilityFactory, UserFactory
+from home.factories import ProjectFactory, TeamFactory
+from home.models import (
+    Project,
+    ProjectPreference,
+    Session,
+    SessionMembership,
+    Survey,
+    Team,
+    UserSurveyResponse,
+)
+from home.team_allocation import (
+    AllocationCandidate,
+    AllocationState,
+    TeamSlot,
+    allocate_teams_bounded_search,
+    apply_allocation,
+    get_allocation_candidates,
+    get_team_slots,
+)
+
+
+class TeamSlotTestCase(TestCase):
+    """Test TeamSlot dataclass functionality."""
+
+    def setUp(self):
+        """Create test data."""
+        self.session = Session.objects.create(
+            title="Test Session",
+            slug="test-session",
+            start_date="2025-06-01",
+            end_date="2025-12-31",
+            invitation_date="2025-01-01",
+            application_start_date="2025-01-15",
+            application_end_date="2025-02-15",
+        )
+        self.project = ProjectFactory(name="Test Project")
+        self.team = TeamFactory(session=self.session, project=self.project)
+
+        # Create navigator with availability
+        self.navigator = UserFactory(username="nav1", email="nav1@test.com")
+        UserAvailabilityFactory(
+            user=self.navigator,
+            slots=[24.0 + (i * 0.5) for i in range(12)],  # Mon 00:00-06:00 (6 hours)
+        )
+        SessionMembership.objects.create(
+            user=self.navigator,
+            session=self.session,
+            team=self.team,
+            role=SessionMembership.NAVIGATOR,
+        )
+
+        # Create captain with availability
+        self.captain = UserFactory(username="captain1", email="captain1@test.com")
+        UserAvailabilityFactory(
+            user=self.captain,
+            slots=[24.0 + (i * 0.5) for i in range(10)],  # Mon 00:00-05:00 (5 hours)
+        )
+        SessionMembership.objects.create(
+            user=self.captain,
+            session=self.session,
+            team=self.team,
+            role=SessionMembership.CAPTAIN,
+        )
+
+        self.team_slot = TeamSlot(
+            team=self.team,
+            navigators=[self.navigator],
+            captain=self.captain,
+            max_djangonauts=3,
+        )
+
+    def test_available_slots(self):
+        """Test calculating available slots."""
+        self.assertEqual(self.team_slot.available_slots, 3)
+
+        # Add a djangonaut
+        user = UserFactory()
+        candidate = AllocationCandidate(
+            user=user, selection_rank=2, score=10, response=None, project_preferences=[]
+        )
+        self.team_slot.add_djangonaut(candidate)
+
+        self.assertEqual(self.team_slot.available_slots, 2)
+
+    def test_is_full(self):
+        """Test checking if team is full."""
+        self.assertFalse(self.team_slot.is_full)
+
+        # Add 3 djangonauts
+        for i in range(3):
+            user = UserFactory(username=f"user{i}")
+            candidate = AllocationCandidate(
+                user=user,
+                selection_rank=2,
+                score=10,
+                response=None,
+                project_preferences=[],
+            )
+            self.team_slot.add_djangonaut(candidate)
+
+        self.assertTrue(self.team_slot.is_full)
+
+    def test_matches_project_preference_no_preferences(self):
+        """Test candidate with no preferences matches any project."""
+        user = UserFactory()
+        candidate = AllocationCandidate(
+            user=user,
+            selection_rank=2,
+            score=10,
+            response=None,
+            project_preferences=[],  # No preferences
+        )
+
+        self.assertTrue(self.team_slot._matches_project_preference(candidate))
+
+    def test_matches_project_preference_with_match(self):
+        """Test candidate with matching preference."""
+        user = UserFactory()
+        candidate = AllocationCandidate(
+            user=user,
+            selection_rank=2,
+            score=10,
+            response=None,
+            project_preferences=[self.project],  # Matches team's project
+        )
+
+        self.assertTrue(self.team_slot._matches_project_preference(candidate))
+
+    def test_matches_project_preference_no_match(self):
+        """Test candidate with non-matching preference."""
+        user = UserFactory()
+        other_project = ProjectFactory(name="Other Project")
+        candidate = AllocationCandidate(
+            user=user,
+            selection_rank=2,
+            score=10,
+            response=None,
+            project_preferences=[other_project],  # Does not match team's project
+        )
+
+        self.assertFalse(self.team_slot._matches_project_preference(candidate))
+
+    def test_has_sufficient_navigator_overlap(self):
+        """Test checking navigator overlap."""
+        # Create user with sufficient overlap (5+ hours)
+        user = UserFactory()
+        UserAvailabilityFactory(
+            user=user,
+            slots=[24.0 + (i * 0.5) for i in range(10)],  # Mon 00:00-05:00 (5 hours)
+        )
+        candidate = AllocationCandidate(
+            user=user, selection_rank=2, score=10, response=None, project_preferences=[]
+        )
+
+        self.assertTrue(self.team_slot._has_sufficient_navigator_overlap(candidate))
+
+        # Create user with insufficient overlap
+        user2 = UserFactory()
+        UserAvailabilityFactory(
+            user=user2,
+            slots=[24.0 + (i * 0.5) for i in range(6)],  # Mon 00:00-03:00 (3 hours)
+        )
+        candidate2 = AllocationCandidate(
+            user=user2,
+            selection_rank=2,
+            score=10,
+            response=None,
+            project_preferences=[],
+        )
+
+        self.assertFalse(self.team_slot._has_sufficient_navigator_overlap(candidate2))
+
+    def test_navigator_overlap_with_existing_djangonauts(self):
+        """Test that navigator overlap check includes existing djangonauts on the team."""
+        # Add first djangonaut to team with Mon 00:00-05:00 availability
+        django1 = UserFactory(username="django1")
+        UserAvailabilityFactory(
+            user=django1,
+            slots=[24.0 + (i * 0.5) for i in range(10)],  # Mon 00:00-05:00
+        )
+        candidate1 = AllocationCandidate(
+            user=django1,
+            selection_rank=2,
+            score=10,
+            response=None,
+            project_preferences=[],
+        )
+        self.team_slot.add_djangonaut(candidate1)
+
+        # Now try to add second djangonaut with Mon 00:00-04:00 availability
+        # Navigator has Mon 00:00-06:00
+        # The overlap between navigator + django1 + django2 should be Mon 00:00-04:00 (4 hours)
+        # which is < 5 hours, so this should fail
+        django2 = UserFactory(username="django2")
+        UserAvailabilityFactory(
+            user=django2,
+            slots=[24.0 + (i * 0.5) for i in range(8)],  # Mon 00:00-04:00 (4 hours)
+        )
+        candidate2 = AllocationCandidate(
+            user=django2,
+            selection_rank=3,
+            score=9,
+            response=None,
+            project_preferences=[],
+        )
+
+        # This should fail because the combined overlap is only 4 hours
+        self.assertFalse(self.team_slot._has_sufficient_navigator_overlap(candidate2))
+
+        # But if django2 has Mon 00:00-05:00+ availability, it should work
+        django3 = UserFactory(username="django3")
+        UserAvailabilityFactory(
+            user=django3,
+            slots=[24.0 + (i * 0.5) for i in range(10)],  # Mon 00:00-05:00 (5 hours)
+        )
+        candidate3 = AllocationCandidate(
+            user=django3,
+            selection_rank=4,
+            score=8,
+            response=None,
+            project_preferences=[],
+        )
+
+        # This should succeed because the combined overlap is 5 hours
+        self.assertTrue(self.team_slot._has_sufficient_navigator_overlap(candidate3))
+
+    def test_has_sufficient_captain_overlap(self):
+        """Test checking captain overlap."""
+        # Create user with sufficient overlap (3+ hours)
+        user = UserFactory()
+        UserAvailabilityFactory(
+            user=user,
+            slots=[24.0 + (i * 0.5) for i in range(6)],  # Mon 00:00-03:00 (3 hours)
+        )
+        candidate = AllocationCandidate(
+            user=user, selection_rank=2, score=10, response=None, project_preferences=[]
+        )
+
+        self.assertTrue(self.team_slot._has_sufficient_captain_overlap(candidate))
+
+        # Create user with insufficient overlap
+        user2 = UserFactory()
+        UserAvailabilityFactory(
+            user=user2,
+            slots=[24.0 + (i * 0.5) for i in range(4)],  # Mon 00:00-02:00 (2 hours)
+        )
+        candidate2 = AllocationCandidate(
+            user=user2,
+            selection_rank=2,
+            score=10,
+            response=None,
+            project_preferences=[],
+        )
+
+        self.assertFalse(self.team_slot._has_sufficient_captain_overlap(candidate2))
+
+    def test_can_add_djangonaut(self):
+        """Test checking if a candidate can be added."""
+        # Create valid candidate
+        user = UserFactory()
+        UserAvailabilityFactory(
+            user=user,
+            slots=[24.0 + (i * 0.5) for i in range(10)],  # Mon 00:00-05:00
+        )
+        candidate = AllocationCandidate(
+            user=user,
+            selection_rank=2,
+            score=10,
+            response=None,
+            project_preferences=[],
+        )
+
+        self.assertTrue(self.team_slot.can_add_djangonaut(candidate))
+
+        # Fill the team
+        for i in range(3):
+            u = UserFactory(username=f"filler{i}")
+            UserAvailabilityFactory(
+                user=u,
+                slots=[24.0 + (i * 0.5) for i in range(10)],
+            )
+            c = AllocationCandidate(
+                user=u,
+                selection_rank=2,
+                score=10,
+                response=None,
+                project_preferences=[],
+            )
+            self.team_slot.add_djangonaut(c)
+
+        # Team is full now
+        self.assertFalse(self.team_slot.can_add_djangonaut(candidate))
+
+    def test_can_add_djangonaut_fails_captain_overlap(self):
+        """
+        Test that candidate is rejected when captain overlap is insufficient.
+
+        Sets up a scenario where:
+        - Navigator has Mon 00:00-06:00
+        - Captain has Tue 00:00-05:00 (different day)
+        - Candidate has Mon 00:00-05:00 + Tue 00:00-02:00
+
+        Result: Candidate passes navigator check (5 hours) but fails captain check (2 hours < 3).
+        """
+        candidate_user = UserFactory()
+        UserAvailabilityFactory(
+            user=candidate_user,
+            slots=(
+                [24.0 + (i * 0.5) for i in range(10)]
+                + [48.0 + (i * 0.5) for i in range(4)]
+            ),
+        )
+
+        captain_with_different_schedule = UserFactory(
+            username="captain2", email="captain2@test.com"
+        )
+        UserAvailabilityFactory(
+            user=captain_with_different_schedule,
+            slots=[48.0 + (i * 0.5) for i in range(10)],
+        )
+
+        team_slot = TeamSlot(
+            team=self.team,
+            navigators=[self.navigator],
+            captain=captain_with_different_schedule,
+            max_djangonauts=3,
+        )
+
+        candidate = AllocationCandidate(
+            user=candidate_user,
+            selection_rank=2,
+            score=10,
+            response=None,
+            project_preferences=[],
+        )
+
+        self.assertFalse(team_slot.can_add_djangonaut(candidate))
+
+    def test_remove_last_djangonaut(self):
+        """Test removing the last djangonaut from a team."""
+        user1 = UserFactory(username="user1")
+        candidate1 = AllocationCandidate(
+            user=user1,
+            selection_rank=2,
+            score=10,
+            response=None,
+            project_preferences=[],
+        )
+        self.team_slot.add_djangonaut(candidate1)
+
+        user2 = UserFactory(username="user2")
+        candidate2 = AllocationCandidate(
+            user=user2, selection_rank=3, score=9, response=None, project_preferences=[]
+        )
+        self.team_slot.add_djangonaut(candidate2)
+
+        self.assertEqual(len(self.team_slot.current_djangonauts), 2)
+        self.assertEqual(self.team_slot.available_slots, 1)
+
+        self.team_slot.remove_last_djangonaut()
+
+        self.assertEqual(len(self.team_slot.current_djangonauts), 1)
+        self.assertEqual(self.team_slot.available_slots, 2)
+        self.assertEqual(self.team_slot.current_djangonauts[0], user1)
+
+    def test_remove_last_djangonaut_empty(self):
+        """Test removing from empty team does nothing."""
+        self.assertEqual(len(self.team_slot.current_djangonauts), 0)
+        self.team_slot.remove_last_djangonaut()
+        self.assertEqual(len(self.team_slot.current_djangonauts), 0)
+
+
+class GetAllocationCandidatesTestCase(TestCase):
+    """Test get_allocation_candidates function."""
+
+    def setUp(self):
+        """Create test data."""
+        self.session = Session.objects.create(
+            title="Test Session",
+            slug="test-session",
+            start_date="2025-06-01",
+            end_date="2025-12-31",
+            invitation_date="2025-01-01",
+            application_start_date="2025-01-15",
+            application_end_date="2025-02-15",
+        )
+        self.survey = Survey.objects.create(
+            name="Application Survey", session=self.session
+        )
+        self.session.application_survey = self.survey
+        self.session.save()
+
+    def test_no_survey(self):
+        """Test when session has no application survey."""
+        session = Session.objects.create(
+            title="No Survey Session",
+            slug="no-survey",
+            start_date="2025-06-01",
+            end_date="2025-12-31",
+            invitation_date="2025-01-01",
+            application_start_date="2025-01-15",
+            application_end_date="2025-02-15",
+        )
+
+        candidates = get_allocation_candidates(session, max_rank=2)
+        self.assertEqual(len(candidates), 0)
+
+    def test_filters_already_assigned(self):
+        """Test that already assigned users are excluded."""
+        user = UserFactory()
+        UserSurveyResponse.objects.create(
+            user=user, survey=self.survey, selection_rank=2, score=10
+        )
+
+        # Assign user to a team
+        team = TeamFactory(session=self.session)
+        SessionMembership.objects.create(
+            user=user,
+            session=self.session,
+            team=team,
+            role=SessionMembership.DJANGONAUT,
+        )
+
+        candidates = get_allocation_candidates(self.session, max_rank=2)
+        self.assertEqual(len(candidates), 0)
+
+    def test_filters_high_selection_rank(self):
+        """Test that selection_rank > 2 are excluded (lower is better)."""
+        user1 = UserFactory(username="user1")
+        UserSurveyResponse.objects.create(
+            user=user1, survey=self.survey, selection_rank=0, score=10
+        )
+
+        user2 = UserFactory(username="user2")
+        UserSurveyResponse.objects.create(
+            user=user2, survey=self.survey, selection_rank=1, score=10
+        )
+
+        user3 = UserFactory(username="user3")
+        UserSurveyResponse.objects.create(
+            user=user3, survey=self.survey, selection_rank=2, score=10
+        )
+
+        user4 = UserFactory(username="user4")
+        UserSurveyResponse.objects.create(
+            user=user4, survey=self.survey, selection_rank=3, score=10
+        )
+
+        candidates = get_allocation_candidates(self.session, max_rank=2)
+        self.assertEqual(len(candidates), 3)
+        candidate_users = [c.user for c in candidates]
+        self.assertIn(user1, candidate_users)
+        self.assertIn(user2, candidate_users)
+        self.assertIn(user3, candidate_users)
+        self.assertNotIn(user4, candidate_users)
+
+    def test_sorting(self):
+        """Test that candidates are sorted by selection_rank ASC, score DESC."""
+        user1 = UserFactory(username="user1")
+        UserSurveyResponse.objects.create(
+            user=user1, survey=self.survey, selection_rank=1, score=5
+        )
+
+        user2 = UserFactory(username="user2")
+        UserSurveyResponse.objects.create(
+            user=user2, survey=self.survey, selection_rank=0, score=8
+        )
+
+        user3 = UserFactory(username="user3")
+        UserSurveyResponse.objects.create(
+            user=user3, survey=self.survey, selection_rank=0, score=10
+        )
+
+        candidates = get_allocation_candidates(self.session, max_rank=2)
+        self.assertEqual(len(candidates), 3)
+
+        self.assertEqual(candidates[0].user, user3)
+        self.assertEqual(candidates[1].user, user2)
+        self.assertEqual(candidates[2].user, user1)
+
+    def test_includes_project_preferences(self):
+        """Test that project preferences are included."""
+        user = UserFactory()
+        response = UserSurveyResponse.objects.create(
+            user=user, survey=self.survey, selection_rank=2, score=10
+        )
+
+        project1 = ProjectFactory(name="Project 1")
+        project2 = ProjectFactory(name="Project 2")
+        ProjectPreference.objects.create(
+            user=user, session=self.session, project=project1
+        )
+        ProjectPreference.objects.create(
+            user=user, session=self.session, project=project2
+        )
+
+        candidates = get_allocation_candidates(self.session, max_rank=2)
+        self.assertEqual(len(candidates), 1)
+        self.assertEqual(len(candidates[0].project_preferences), 2)
+        self.assertIn(project1, candidates[0].project_preferences)
+        self.assertIn(project2, candidates[0].project_preferences)
+
+
+class GetTeamSlotsTestCase(TestCase):
+    """Test get_team_slots function."""
+
+    def setUp(self):
+        """Create test data."""
+        self.session = Session.objects.create(
+            title="Test Session",
+            slug="test-session",
+            start_date="2025-06-01",
+            end_date="2025-12-31",
+            invitation_date="2025-01-01",
+            application_start_date="2025-01-15",
+            application_end_date="2025-02-15",
+        )
+
+    def test_empty_session(self):
+        """Test session with no teams."""
+        team_slots = get_team_slots(self.session)
+        self.assertEqual(len(team_slots), 0)
+
+    def test_excludes_full_teams(self):
+        """Test that teams with 3 Djangonauts are excluded."""
+        team = TeamFactory(session=self.session)
+        navigator = UserFactory(username="nav")
+        SessionMembership.objects.create(
+            user=navigator,
+            session=self.session,
+            team=team,
+            role=SessionMembership.NAVIGATOR,
+        )
+
+        # Add 3 Djangonauts
+        for i in range(3):
+            user = UserFactory(username=f"django{i}")
+            SessionMembership.objects.create(
+                user=user,
+                session=self.session,
+                team=team,
+                role=SessionMembership.DJANGONAUT,
+            )
+
+        team_slots = get_team_slots(self.session)
+        self.assertEqual(len(team_slots), 0)
+
+    def test_includes_partial_teams(self):
+        """Test that teams with < 3 Djangonauts are included."""
+        team = TeamFactory(session=self.session)
+        navigator = UserFactory(username="nav")
+        SessionMembership.objects.create(
+            user=navigator,
+            session=self.session,
+            team=team,
+            role=SessionMembership.NAVIGATOR,
+        )
+
+        # Add 1 Djangonaut
+        user = UserFactory(username="django1")
+        SessionMembership.objects.create(
+            user=user,
+            session=self.session,
+            team=team,
+            role=SessionMembership.DJANGONAUT,
+        )
+
+        team_slots = get_team_slots(self.session)
+        self.assertEqual(len(team_slots), 1)
+        self.assertEqual(team_slots[0].available_slots, 2)
+
+    def test_includes_navigators_and_captain(self):
+        """Test that navigators and captain are included."""
+        team = TeamFactory(session=self.session)
+
+        nav1 = UserFactory(username="nav1")
+        nav2 = UserFactory(username="nav2")
+        captain = UserFactory(username="captain")
+
+        SessionMembership.objects.create(
+            user=nav1, session=self.session, team=team, role=SessionMembership.NAVIGATOR
+        )
+        SessionMembership.objects.create(
+            user=nav2, session=self.session, team=team, role=SessionMembership.NAVIGATOR
+        )
+        SessionMembership.objects.create(
+            user=captain,
+            session=self.session,
+            team=team,
+            role=SessionMembership.CAPTAIN,
+        )
+
+        team_slots = get_team_slots(self.session)
+        self.assertEqual(len(team_slots), 1)
+        self.assertEqual(len(team_slots[0].navigators), 2)
+        self.assertEqual(team_slots[0].captain, captain)
+
+
+class AllocationStateTestCase(TestCase):
+    """Test AllocationState dataclass."""
+
+    def test_get_score(self):
+        """Test calculating allocation score."""
+        # Create mock data
+        team = TeamFactory()
+        team_slot = TeamSlot(team=team, navigators=[], captain=None)
+
+        user1 = UserFactory(username="user1")
+        candidate1 = AllocationCandidate(
+            user=user1,
+            selection_rank=2,
+            score=10,
+            response=None,
+            project_preferences=[],
+        )
+
+        user2 = UserFactory(username="user2")
+        candidate2 = AllocationCandidate(
+            user=user2, selection_rank=3, score=8, response=None, project_preferences=[]
+        )
+
+        # Add candidates to team
+        team_slot.add_djangonaut(candidate1)
+        team_slot.add_djangonaut(candidate2)
+
+        state = AllocationState(
+            teams=[team_slot],
+            allocated_candidates=[(candidate1, team_slot), (candidate2, team_slot)],
+            unallocated_candidates=[],
+        )
+
+        score = state.get_score()
+        # (num_allocated=2, num_complete=0, -sum_of_ranks=-(2+3)=-5)
+        self.assertEqual(score, (2, 0, -5))
+
+        # Add third candidate to make team complete
+        user3 = UserFactory(username="user3")
+        candidate3 = AllocationCandidate(
+            user=user3, selection_rank=4, score=7, response=None, project_preferences=[]
+        )
+        team_slot.add_djangonaut(candidate3)
+        state.allocated_candidates.append((candidate3, team_slot))
+
+        score = state.get_score()
+        # (num_allocated=3, num_complete=1, -sum_of_ranks=-(2+3+4)=-9)
+        self.assertEqual(score, (3, 1, -9))
+
+
+class AllocateTeamsBoundedSearchTestCase(TestCase):
+    """Test the main allocation algorithm."""
+
+    def setUp(self):
+        """Create test data."""
+        self.session = Session.objects.create(
+            title="Test Session",
+            slug="test-session",
+            start_date="2025-06-01",
+            end_date="2025-12-31",
+            invitation_date="2025-01-01",
+            application_start_date="2025-01-15",
+            application_end_date="2025-02-15",
+        )
+        self.survey = Survey.objects.create(
+            name="Application Survey", session=self.session
+        )
+        self.session.application_survey = self.survey
+        self.session.save()
+
+        # Create a project
+        self.project = ProjectFactory(name="Django")
+
+        # Create team with navigator and captain
+        self.team = TeamFactory(session=self.session, project=self.project)
+
+        self.navigator = UserFactory(username="navigator")
+        UserAvailabilityFactory(
+            user=self.navigator,
+            slots=[24.0 + (i * 0.5) for i in range(12)],  # Mon 00:00-06:00
+        )
+        SessionMembership.objects.create(
+            user=self.navigator,
+            session=self.session,
+            team=self.team,
+            role=SessionMembership.NAVIGATOR,
+        )
+
+        self.captain = UserFactory(username="captain")
+        UserAvailabilityFactory(
+            user=self.captain,
+            slots=[24.0 + (i * 0.5) for i in range(10)],  # Mon 00:00-05:00
+        )
+        SessionMembership.objects.create(
+            user=self.captain,
+            session=self.session,
+            team=self.team,
+            role=SessionMembership.CAPTAIN,
+        )
+
+    def test_no_candidates(self):
+        """Test allocation with no candidates."""
+        allocation = allocate_teams_bounded_search(self.session)
+        self.assertEqual(len(allocation.allocated_candidates), 0)
+
+    def test_no_teams(self):
+        """Test allocation with no teams."""
+        # Remove the team
+        self.team.delete()
+
+        # Create a candidate
+        user = UserFactory()
+        UserSurveyResponse.objects.create(
+            user=user, survey=self.survey, selection_rank=2, score=10
+        )
+
+        allocation = allocate_teams_bounded_search(self.session)
+        self.assertEqual(len(allocation.allocated_candidates), 0)
+
+    def test_basic_allocation(self):
+        """Test basic allocation with compatible candidates."""
+        candidates = []
+        for i in range(3):
+            user = UserFactory(username=f"applicant{i}")
+            UserAvailabilityFactory(
+                user=user,
+                slots=[24.0 + (j * 0.5) for j in range(10)],
+            )
+            UserSurveyResponse.objects.create(
+                user=user, survey=self.survey, selection_rank=i, score=10 - i
+            )
+            candidates.append(user)
+
+        allocation = allocate_teams_bounded_search(self.session)
+        self.assertEqual(len(allocation.allocated_candidates), 3)
+
+        allocated_users = [c.user for c, _ in allocation.allocated_candidates]
+        self.assertEqual(allocated_users[0], candidates[0])
+        self.assertEqual(allocated_users[1], candidates[1])
+        self.assertEqual(allocated_users[2], candidates[2])
+
+    def test_respects_availability_constraints(self):
+        """Test that candidates without sufficient overlap are not allocated."""
+        user1 = UserFactory(username="applicant1")
+        UserAvailabilityFactory(
+            user=user1,
+            slots=[24.0 + (i * 0.5) for i in range(6)],
+        )
+        UserSurveyResponse.objects.create(
+            user=user1, survey=self.survey, selection_rank=0, score=10
+        )
+
+        user2 = UserFactory(username="applicant2")
+        UserAvailabilityFactory(
+            user=user2,
+            slots=[24.0 + (i * 0.5) for i in range(10)],
+        )
+        UserSurveyResponse.objects.create(
+            user=user2, survey=self.survey, selection_rank=1, score=9
+        )
+
+        allocation = allocate_teams_bounded_search(self.session)
+        self.assertEqual(len(allocation.allocated_candidates), 1)
+        self.assertEqual(allocation.allocated_candidates[0][0].user, user2)
+
+    def test_respects_project_preferences(self):
+        """Test that project preferences are respected."""
+        other_project = ProjectFactory(name="Wagtail")
+
+        user1 = UserFactory(username="applicant1")
+        UserAvailabilityFactory(
+            user=user1,
+            slots=[24.0 + (i * 0.5) for i in range(10)],
+        )
+        UserSurveyResponse.objects.create(
+            user=user1, survey=self.survey, selection_rank=0, score=10
+        )
+        ProjectPreference.objects.create(
+            user=user1, session=self.session, project=other_project
+        )
+
+        user2 = UserFactory(username="applicant2")
+        UserAvailabilityFactory(
+            user=user2,
+            slots=[24.0 + (i * 0.5) for i in range(10)],
+        )
+        UserSurveyResponse.objects.create(
+            user=user2, survey=self.survey, selection_rank=1, score=9
+        )
+        ProjectPreference.objects.create(
+            user=user2, session=self.session, project=self.project
+        )
+
+        allocation = allocate_teams_bounded_search(self.session)
+        self.assertEqual(len(allocation.allocated_candidates), 1)
+        self.assertEqual(allocation.allocated_candidates[0][0].user, user2)
+
+    def test_prefers_higher_ranked_candidates(self):
+        """Test that higher-ranked candidates are preferred (lower rank number is better)."""
+        candidates = []
+        for i in range(5):
+            user = UserFactory(username=f"applicant{i}")
+            UserAvailabilityFactory(
+                user=user,
+                slots=[24.0 + (j * 0.5) for j in range(10)],
+            )
+            UserSurveyResponse.objects.create(
+                user=user, survey=self.survey, selection_rank=i, score=10
+            )
+            candidates.append(user)
+
+        allocation = allocate_teams_bounded_search(self.session)
+        self.assertEqual(len(allocation.allocated_candidates), 3)
+
+        allocated_users = [c.user for c, _ in allocation.allocated_candidates]
+        self.assertIn(candidates[0], allocated_users)
+        self.assertIn(candidates[1], allocated_users)
+        self.assertIn(candidates[2], allocated_users)
+        self.assertNotIn(candidates[3], allocated_users)
+        self.assertNotIn(candidates[4], allocated_users)
+
+    def test_diminishing_overlap_with_multiple_djangonauts(self):
+        """Test that algorithm respects diminishing overlap as more djangonauts are added."""
+        user1 = UserFactory(username="applicant1")
+        UserAvailabilityFactory(
+            user=user1,
+            slots=[24.0 + (i * 0.5) for i in range(12)],
+        )
+        UserSurveyResponse.objects.create(
+            user=user1, survey=self.survey, selection_rank=0, score=10
+        )
+
+        user2 = UserFactory(username="applicant2")
+        UserAvailabilityFactory(
+            user=user2,
+            slots=[24.0 + (i * 0.5) for i in range(10)],
+        )
+        UserSurveyResponse.objects.create(
+            user=user2, survey=self.survey, selection_rank=1, score=9
+        )
+
+        user3 = UserFactory(username="applicant3")
+        UserAvailabilityFactory(
+            user=user3,
+            slots=[24.0 + (i * 0.5) for i in range(8)],
+        )
+        UserSurveyResponse.objects.create(
+            user=user3, survey=self.survey, selection_rank=2, score=8
+        )
+
+        allocation = allocate_teams_bounded_search(self.session)
+
+        self.assertEqual(len(allocation.allocated_candidates), 2)
+        allocated_users = [c.user for c, _ in allocation.allocated_candidates]
+        self.assertIn(user1, allocated_users)
+        self.assertIn(user2, allocated_users)
+        self.assertNotIn(user3, allocated_users)
+
+    def test_phase2_allocation_with_rank3_candidates(self):
+        """
+        Test that rank 3 candidates are allocated in phase 2 when teams have space.
+
+        The allocation algorithm works in two phases:
+        - Phase 1: Allocates candidates with selection_rank 0-2
+        - Phase 2: If teams still have slots, allocates candidates with selection_rank 3
+
+        This test verifies that:
+        1. Phase 1 allocates rank 0-2 candidates (user1, user2) filling 2 of 3 team slots
+        2. Phase 2 detects remaining capacity and allocates rank 3 candidate (user3)
+        3. All 3 candidates end up allocated across both phases
+        """
+        user1 = UserFactory(username="applicant1")
+        UserAvailabilityFactory(
+            user=user1,
+            slots=[24.0 + (i * 0.5) for i in range(10)],
+        )
+        UserSurveyResponse.objects.create(
+            user=user1, survey=self.survey, selection_rank=0, score=10
+        )
+
+        user2 = UserFactory(username="applicant2")
+        UserAvailabilityFactory(
+            user=user2,
+            slots=[24.0 + (i * 0.5) for i in range(10)],
+        )
+        UserSurveyResponse.objects.create(
+            user=user2, survey=self.survey, selection_rank=1, score=9
+        )
+
+        user3 = UserFactory(username="applicant3")
+        UserAvailabilityFactory(
+            user=user3,
+            slots=[24.0 + (i * 0.5) for i in range(10)],
+        )
+        UserSurveyResponse.objects.create(
+            user=user3, survey=self.survey, selection_rank=3, score=8
+        )
+
+        allocation = allocate_teams_bounded_search(self.session)
+
+        self.assertEqual(len(allocation.allocated_candidates), 3)
+        allocated_users = [c.user for c, _ in allocation.allocated_candidates]
+        self.assertIn(user1, allocated_users)
+        self.assertIn(user2, allocated_users)
+        self.assertIn(user3, allocated_users)
+
+
+class ApplyAllocationTestCase(TestCase):
+    """Test applying allocation to database."""
+
+    def setUp(self):
+        """Create test data."""
+        self.session = Session.objects.create(
+            title="Test Session",
+            slug="test-session",
+            start_date="2025-06-01",
+            end_date="2025-12-31",
+            invitation_date="2025-01-01",
+            application_start_date="2025-01-15",
+            application_end_date="2025-02-15",
+        )
+        self.survey = Survey.objects.create(
+            name="Application Survey", session=self.session
+        )
+        self.session.application_survey = self.survey
+        self.session.save()
+
+        self.team = TeamFactory(session=self.session)
+
+    def test_creates_memberships(self):
+        """Test that SessionMembership records are created."""
+        team_slot = TeamSlot(team=self.team, navigators=[], captain=None)
+
+        user1 = UserFactory(username="user1")
+        response1 = UserSurveyResponse.objects.create(
+            user=user1, survey=self.survey, selection_rank=2, score=10
+        )
+        candidate1 = AllocationCandidate(
+            user=user1,
+            selection_rank=2,
+            score=10,
+            response=response1,
+            project_preferences=[],
+        )
+
+        user2 = UserFactory(username="user2")
+        response2 = UserSurveyResponse.objects.create(
+            user=user2, survey=self.survey, selection_rank=3, score=9
+        )
+        candidate2 = AllocationCandidate(
+            user=user2,
+            selection_rank=3,
+            score=9,
+            response=response2,
+            project_preferences=[],
+        )
+
+        allocation = AllocationState(
+            teams=[team_slot],
+            allocated_candidates=[(candidate1, team_slot), (candidate2, team_slot)],
+            unallocated_candidates=[],
+        )
+
+        stats = apply_allocation(allocation, self.session)
+
+        self.assertEqual(stats["created"], 2)
+        self.assertEqual(
+            SessionMembership.objects.filter(
+                session=self.session, role=SessionMembership.DJANGONAUT
+            ).count(),
+            2,
+        )
+
+        # Verify the memberships
+        membership1 = SessionMembership.objects.get(user=user1)
+        self.assertEqual(membership1.team, self.team)
+        self.assertEqual(membership1.role, SessionMembership.DJANGONAUT)
+
+        membership2 = SessionMembership.objects.get(user=user2)
+        self.assertEqual(membership2.team, self.team)
+        self.assertEqual(membership2.role, SessionMembership.DJANGONAUT)
+
+    def test_returns_statistics(self):
+        """Test that statistics are returned correctly."""
+        team_slot = TeamSlot(team=self.team, navigators=[], captain=None)
+
+        # Add 3 candidates to make team complete
+        candidates = []
+        for i in range(3):
+            user = UserFactory(username=f"user{i}")
+            response = UserSurveyResponse.objects.create(
+                user=user, survey=self.survey, selection_rank=2 + i, score=10
+            )
+            candidate = AllocationCandidate(
+                user=user,
+                selection_rank=2 + i,
+                score=10,
+                response=response,
+                project_preferences=[],
+            )
+            candidates.append((candidate, team_slot))
+            team_slot.add_djangonaut(candidate)
+
+        allocation = AllocationState(
+            teams=[team_slot],
+            allocated_candidates=candidates,
+            unallocated_candidates=[],
+        )
+
+        stats = apply_allocation(allocation, self.session)
+
+        self.assertEqual(stats["created"], 3)
+        self.assertEqual(stats["complete_teams"], 1)
+        self.assertEqual(stats["total_teams"], 1)


### PR DESCRIPTION
This action attempts to place all members with the lowest selection rank on teams first, then moves onto the next selection rank. This continues until we have full teams up to a certain extent.