### PR TITLE
Fix vertical images block flex wrapping.

### DIFF
--- a/indymeet/templates/blocks/vertical_image_cards_block.html
+++ b/indymeet/templates/blocks/vertical_image_cards_block.html
@@ -1,7 +1,7 @@
 {% load wagtailcore_tags wagtailimages_tags %}
-<div class="flex md:flex-wrap place-content-center">
+<div class="flex flex-wrap justify-center">
 {% for child in self %}
-<div class="max-w-sm flex-initial w-80 rounded overflow-hidden shadow-lg my-3 mx-3 ">
+  <div class="max-w-sm flex-initial w-80 rounded overflow-hidden shadow-lg my-3 mx-3 ">
     {% if child.value.link %}
         <a class="text-black" href="{{ child.value.link }}">
     {% endif %}
@@ -22,5 +22,4 @@
     </div>
   </div>
 {% endfor %}
-
 </div>


### PR DESCRIPTION
Support wrapping the images on smaller viewports to avoid a horizontal scroll.

#### Broken
<img width="556" height="741" alt="Screenshot from 2025-12-04 15-19-18" src="https://github.com/user-attachments/assets/bd993578-8c2e-4dd4-93b4-da66c22fd2a8" />


#### Fixed
<img width="535" height="728" alt="Screenshot from 2025-12-04 15-19-02" src="https://github.com/user-attachments/assets/d095755b-9664-4430-bada-4bdaff7b0573" />
