### PR TITLE
Add session membership admin action to find overlapping avaiability

### DIFF
--- a/home/templates/admin/availability_overlap_message.html
+++ b/home/templates/admin/availability_overlap_message.html
@@ -1,0 +1,18 @@
+{% load email_tags %}
+<strong>Top {{ results|length }} availability overlap(s) for {{ total_members }} selected member(s):</strong>
+<ol>
+    {% for window in results %}
+    <li>
+        <strong><a href="{{ window.start_datetime|time_is_link }}" target="_blank">{{ window.formatted_time }} UTC</a></strong>:
+        {{ window.total_available }} member(s) available ({{ window.role_summary }})
+        <br>
+        {% if window.unavailable_member_ids %}
+          <a href="{{ window.admin_unavailable_url }}" target="_blank">
+              View {{ window.unavailable_member_ids|length }} unavailable member(s). Re-run this action with those {{ window.unavailable_member_ids|length }} users selected to find an optimal second time.
+          </a>
+        {% else %}
+          All members available!
+        {% endif %}
+    </li>
+    {% endfor %}
+</ol>

--- a/home/tests/test_admin_session_membership.py
+++ b/home/tests/test_admin_session_membership.py
@@ -1,12 +1,15 @@
-"""Tests for admin inlines."""
+"""Tests for admin inlines and admin actions."""
 
 from unittest.mock import Mock
 
+from django.contrib import messages
 from django.contrib.admin.sites import AdminSite
+from django.contrib.messages.storage.fallback import FallbackStorage
 from django.test import TestCase, RequestFactory
 
 from accounts.factories import UserFactory
-from home.admin import SessionMembershipInline
+from accounts.models import UserAvailability
+from home.admin import SessionMembershipAdmin, SessionMembershipInline
 from home.factories import SessionFactory, SessionMembershipFactory, TeamFactory
 from home.models import Session, SessionMembership
 
@@ -73,3 +76,181 @@ class SessionMembershipInlineTests(TestCase):
 
         # Team queryset should be empty
         self.assertEqual(formfield.queryset.count(), 0)
+
+
+class FindBestAvailabilityOverlapsActionTests(TestCase):
+    """Tests for the find_best_availability_overlaps_action admin action."""
+
+    def setUp(self):
+        """Set up test data."""
+        self.factory = RequestFactory()
+        self.admin_site = AdminSite()
+        self.model_admin = SessionMembershipAdmin(SessionMembership, self.admin_site)
+        self.session = SessionFactory.create(title="Test Session")
+
+        self.user1 = UserFactory.create(email="user1@example.com")
+        self.user2 = UserFactory.create(email="user2@example.com")
+        self.user3 = UserFactory.create(email="user3@example.com")
+
+        self.membership1 = SessionMembershipFactory.create(
+            session=self.session,
+            user=self.user1,
+            role=SessionMembership.DJANGONAUT,
+        )
+        self.membership2 = SessionMembershipFactory.create(
+            session=self.session,
+            user=self.user2,
+            role=SessionMembership.CAPTAIN,
+        )
+        self.membership3 = SessionMembershipFactory.create(
+            session=self.session,
+            user=self.user3,
+            role=SessionMembership.NAVIGATOR,
+        )
+
+    def test_action_requires_at_least_two_members(self):
+        """Test that action shows error when less than 2 members selected."""
+        request = self.factory.get("/admin/home/sessionmembership/")
+        request.session = {}
+        request._messages = FallbackStorage(request)
+
+        queryset = SessionMembership.objects.filter(id=self.membership1.id)
+
+        self.model_admin.find_best_availability_overlaps_action(request, queryset)
+
+        message_list = list(request._messages)
+        self.assertEqual(len(message_list), 1)
+        self.assertEqual(message_list[0].level, messages.ERROR)
+        self.assertIn("at least 2 members", str(message_list[0].message))
+
+    def test_action_with_no_availability_data(self):
+        """Test action when members have no availability set."""
+        request = self.factory.get("/admin/home/sessionmembership/")
+        request.session = {}
+        request._messages = FallbackStorage(request)
+
+        queryset = SessionMembership.objects.filter(
+            id__in=[self.membership1.id, self.membership2.id]
+        )
+
+        self.model_admin.find_best_availability_overlaps_action(request, queryset)
+
+        message_list = list(request._messages)
+        self.assertEqual(len(message_list), 1)
+        self.assertEqual(message_list[0].level, messages.WARNING)
+        self.assertIn("No overlapping", str(message_list[0].message))
+
+    def test_action_with_overlapping_availability(self):
+        """Test action successfully finds overlapping availability."""
+        UserAvailability.objects.create(
+            user=self.user1,
+            slots=[24.0, 24.5, 25.0, 25.5, 26.0, 26.5],
+        )
+        UserAvailability.objects.create(
+            user=self.user2,
+            slots=[24.0, 24.5, 25.0, 25.5, 26.0, 26.5],
+        )
+        UserAvailability.objects.create(
+            user=self.user3,
+            slots=[24.0, 24.5, 30.0, 30.5],
+        )
+
+        request = self.factory.get("/admin/home/sessionmembership/")
+        request.session = {}
+        request._messages = FallbackStorage(request)
+
+        queryset = SessionMembership.objects.filter(
+            id__in=[self.membership1.id, self.membership2.id, self.membership3.id]
+        )
+
+        self.model_admin.find_best_availability_overlaps_action(request, queryset)
+
+        message_list = list(request._messages)
+        self.assertEqual(len(message_list), 1)
+
+        message = str(message_list[0].message)
+        self.assertIn("Mon 12:00 AM - 1:00 AM", message)
+        self.assertIn("Djangonaut: 1", message)
+        self.assertIn("Captain: 1", message)
+        self.assertIn("Navigator: 1", message)
+
+    def test_action_shows_unavailable_member_link(self):
+        """Test that action includes link to unavailable members."""
+        UserAvailability.objects.create(
+            user=self.user1,
+            slots=[24.0, 24.5],
+        )
+        UserAvailability.objects.create(
+            user=self.user2,
+            slots=[24.0, 24.5],
+        )
+        UserAvailability.objects.create(
+            user=self.user3,
+            slots=[30.0, 30.5],
+        )
+
+        request = self.factory.get("/admin/home/sessionmembership/")
+        request.session = {}
+        request._messages = FallbackStorage(request)
+
+        queryset = SessionMembership.objects.filter(
+            id__in=[self.membership1.id, self.membership2.id, self.membership3.id]
+        )
+
+        self.model_admin.find_best_availability_overlaps_action(request, queryset)
+
+        message_list = list(request._messages)
+        message = str(message_list[0].message)
+
+        self.assertIn("View 1 unavailable member(s)", message)
+        self.assertIn("/django-admin/home/sessionmembership/?user_id__in=", message)
+
+    def test_action_shows_all_members_available(self):
+        """Test message when all members are available for a time slot."""
+        UserAvailability.objects.create(
+            user=self.user1,
+            slots=[24.0, 24.5],
+        )
+        UserAvailability.objects.create(
+            user=self.user2,
+            slots=[24.0, 24.5],
+        )
+
+        request = self.factory.get("/admin/home/sessionmembership/")
+        request.session = {}
+        request._messages = FallbackStorage(request)
+
+        queryset = SessionMembership.objects.filter(
+            id__in=[self.membership1.id, self.membership2.id]
+        )
+
+        self.model_admin.find_best_availability_overlaps_action(request, queryset)
+
+        message_list = list(request._messages)
+        message = str(message_list[0].message)
+
+        self.assertIn("All members available!", message)
+
+    def test_action_message_level_based_on_result_count(self):
+        """Test that message level is INFO for <5 results, SUCCESS for 5+."""
+        UserAvailability.objects.create(
+            user=self.user1,
+            slots=[24.0, 24.5, 25.0, 25.5],
+        )
+        UserAvailability.objects.create(
+            user=self.user2,
+            slots=[24.0, 24.5, 25.0, 25.5],
+        )
+
+        request = self.factory.get("/admin/home/sessionmembership/")
+        request.session = {}
+        request._messages = FallbackStorage(request)
+
+        queryset = SessionMembership.objects.filter(
+            id__in=[self.membership1.id, self.membership2.id]
+        )
+
+        self.model_admin.find_best_availability_overlaps_action(request, queryset)
+
+        message_list = list(request._messages)
+        self.assertEqual(message_list[0].level, messages.INFO)


### PR DESCRIPTION
On the Session Membership admin view, select the users you'd like to see the overlapping availability for. It will show the top 10 options. It also provides a link that will filter down to the unavailable members so the process can be repeated to find an ideal second time.

<img width="940" height="821" alt="Screenshot from 2025-12-08 11-26-52" src="https://github.com/user-attachments/assets/9c0c4d0b-340b-46b3-bd7d-ec3fe87b8e51" />
<img width="1002" height="448" alt="Screenshot from 2025-12-08 11-26-44" src="https://github.com/user-attachments/assets/c108ffbe-663a-4327-a2f0-6afff42901fa" />
