### PR TITLE
Support disabling the email confirmation for load tests.

### DIFF
--- a/accounts/views.py
+++ b/accounts/views.py
@@ -1,4 +1,5 @@
 # Create your views here.
+from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth import get_user_model
 from django.contrib.auth import login
@@ -103,15 +104,27 @@ class SignUpView(CreateView):
         user.profile.receiving_event_updates = form.cleaned_data[
             "receive_event_updates"
         ]
-        user.profile.save(
-            update_fields=[
-                "accepted_coc",
-                "receiving_newsletter",
-                "receiving_program_updates",
-                "receiving_event_updates",
-            ]
-        )
-        send_user_confirmation_email(self.request, user)
+        if settings.LOAD_TESTING:
+            user.profile.email_confirmed = True
+            user.profile.save(
+                update_fields=[
+                    "email_confirmed",
+                    "accepted_coc",
+                    "receiving_newsletter",
+                    "receiving_program_updates",
+                    "receiving_event_updates",
+                ]
+            )
+        else:
+            user.profile.save(
+                update_fields=[
+                    "accepted_coc",
+                    "receiving_newsletter",
+                    "receiving_program_updates",
+                    "receiving_event_updates",
+                ]
+            )
+            send_user_confirmation_email(self.request, user)
         return super().form_valid(form)
 
 

--- a/indymeet/settings/base.py
+++ b/indymeet/settings/base.py
@@ -280,3 +280,7 @@ ALLOWED_EMAILS_FOR_TESTING = [
     for email in (os.environ.get("ALLOWED_EMAILS_FOR_TESTING") or "").split(";")
     if email
 ]
+
+# When running load tests, it's helpful to remove some functionality
+# such as confirmation emails.
+LOAD_TESTING = os.environ.get("LOAD_TESTING", False)


### PR DESCRIPTION
When running the load tests, we're going to want to create several users which need to confirm their emails before being able to apply for a session. This allows any new user signed up while this setting is set to true to skip that process.

Refs #617