### PR TITLE
Add load test for signing up and submitting applications.

### DIFF
--- a/load_tests/README.md
+++ b/load_tests/README.md
@@ -12,3 +12,29 @@ To run a test:
 ```shell
 k6 run test_blog.js
 ```
+
+## Testing the application flow
+
+There is a load test that covers signing up, logging in, setting availability then submitting an application. The following are the instructions on how to run it.
+
+1. SSH into server (see [deployment docs](../docs/deployment.md))
+   ```bash
+   ssh root@djangonaut.space
+   ```
+2. Enable load testing configuration
+   ```bash
+   dokku config:set staging LOAD_TESTING=True
+   ```
+3. Monitor logs and [Sentry performance](https://djangonaut-space.sentry.io/explore/profiling/?project=4506747129626624&statsPeriod=1h)
+   ```bash
+   dokku logs staging -t
+   ```
+4. On local machine, run tests
+   ```bash
+   k6 run test_application.js
+   ```
+5. Undo loading configuration
+   ```bash
+   dokku config:unset staging LOAD_TESTING
+   ```
+6. Delete [load test users](https://staging.djangonaut.space/django-admin/accounts/customuser/?q=load_test)

--- a/load_tests/test_application.js
+++ b/load_tests/test_application.js
@@ -1,0 +1,112 @@
+import http from "k6/http";
+import { check, sleep } from "k6";
+import exec from 'k6/execution';
+
+// Test configuration
+export const options = {
+  thresholds: {
+    // Assert that 99% of requests finish within 3000ms.
+    http_req_duration: ["p(99) < 3000"],
+  },
+  // Ramp the number of virtual users up and down
+  stages: [
+    { duration: "1m", target: 20 },
+  ],
+};
+
+const PASSWORD = 'h@nter2!!'; // Reset the password on production
+
+const AVAILABILITY = {
+  0: [0.0, 0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0, 4.5, 5.0],
+  1: [24.0, 24.5, 25.0, 25.5, 26.0, 26.5, 27.0, 27.5, 28.0, 28.5, 29.0],
+  2: [48.0, 48.5, 49.0, 49.5, 50.0, 50.5, 51.0, 51.5, 52.0, 52.5, 53.0],
+  3: [72.0, 72.5, 73.0, 73.5, 74.0, 74.5, 75.0, 75.5, 76.0, 76.5, 77.0],
+}
+
+function login(testIndex) {
+  let res = http.get("https://staging.djangonaut.space/accounts/login/");
+  check(res, { "status was 200": (r) => r.status == 200 });
+  res = res.submitForm({
+    formSelector: 'form',
+    fields: {
+      username: `load_test${testIndex}`,
+      password: PASSWORD,
+    },
+    params: {
+      headers: {
+        'Referer': res.url,
+      },
+    },
+  });
+  check(res, { "status was 200": (r) => r.status == 200 });
+}
+
+function createAccount(testIndex) {
+  let res = http.get("https://staging.djangonaut.space/accounts/signup/");
+  check(res, { "status was 200": (r) => r.status == 200 });
+  res = res.submitForm({
+    formSelector: 'form',
+    fields: {
+      username: `load_test${testIndex}`,
+      email: `load_test${testIndex}@test.com`,
+      password1: PASSWORD,
+      password2: PASSWORD,
+      first_name: `first_name_${testIndex}`,
+      last_name: `last_name_${testIndex}`,
+      email_consent: true,
+      accepted_coc: true,
+    },
+    params: {
+      headers: {
+        'Referer': res.url,
+      },
+    },
+  });
+  check(res, { "status was 200": (r) => r.status == 200 });
+}
+
+function submitApplication(testIndex) {
+  let res = http.get("https://staging.djangonaut.space/survey/load-test/response/create/");
+  check(res, { "status was 200": (r) => r.status == 200 });
+  res = res.submitForm({
+    formSelector: `form[action!='/accounts/logout/']`,
+    fields: {
+      field_survey_1: 'load_test',
+      field_survey_2: 2,
+      field_survey_3: "Final answer",
+      github_username: `test-djangonautspace-${testIndex}`
+    },
+    params: {
+      headers: {
+        'Referer': res.url,
+      },
+    },
+  });
+  check(res, { "status was 200": (r) => r.status == 200 });
+}
+
+function setAvailability(testIndex) {
+  let res = http.get("https://staging.djangonaut.space/accounts/availability/");
+  check(res, { "status was 200": (r) => r.status == 200 });
+  res = res.submitForm({
+    formSelector: `form[action!='/accounts/logout/']`,
+    fields: {
+      slots: JSON.stringify(AVAILABILITY[testIndex % 4]),
+    },
+    params: {
+      headers: {
+        'Referer': res.url,
+      },
+    },
+  });
+  check(res, { "status was 200": (r) => r.status == 200 });
+}
+
+// Simulated user behavior
+export default function () {
+  createAccount(exec.scenario.iterationInTest);
+  login(exec.scenario.iterationInTest)
+  submitApplication(exec.scenario.iterationInTest)
+  setAvailability(exec.scenario.iterationInTest)
+  sleep(1);
+}


### PR DESCRIPTION
See load_tests/README.md for instructions.

Refs #617

This allows us to run a load test against a test survey. It's fairly hardcoded and to run it requires access to the staging server to disable recaptcha and email confirmations.

Below are the logs of the run against staging. It created 45 users, set their availability and submitted a basic application. There was degradation in the server. Requests were taking 4s (likely when we had 20 concurrent users). That said, the majority of that was spent on the login view which is an expensive call due to the password hashing.

While not great, **I think this is reasonable to move forward with since we had about 1 user per hour submit an application for session 5.** @RachellCalhoun can you let me know if you agree with this?
<details>

<summary>K6 load test output</summary>

```console
❯ k6 run test_application.js
WARN[0000] The configuration file has been found on the old default path ("/home/schillingt/.config/loadimpact/k6/config.json"). Please, run `k6 cloud login` or `k6 login` to migrate to the new default path.
 

         /\      Grafana   /‾‾/  
    /\  /  \     |\  __   /  /   
   /  \/    \    | |/ /  /   ‾‾\ 
  /          \   |   (  |  (‾)  |
 / __________ \  |_|\_\  \_____/ 

     execution: local
        script: test_application.js
        output: -

     scenarios: (100.00%) 1 scenario, 20 max VUs, 1m30s max duration (incl. graceful stop):
              * default: Up to 20 looping VUs for 1m0s over 1 stages (gracefulRampDown: 30s, gracefulStop: 30s)



  █ THRESHOLDS 

    http_req_duration
    ✗ 'p(99) < 3000' p(99)=5.32s


  █ TOTAL RESULTS 

    checks_total.......: 360     5.436576/s
    checks_succeeded...: 100.00% 360 out of 360
    checks_failed......: 0.00%   0 out of 360

    ✓ status was 200

    HTTP
    http_req_duration..............: avg=1.21s  min=37.67ms med=779.58ms max=6.17s  p(90)=2.86s  p(95)=3.76s 
      { expected_response:true }...: avg=1.21s  min=37.67ms med=779.58ms max=6.17s  p(90)=2.86s  p(95)=3.76s 
    http_req_failed................: 0.00%  0 out of 540
    http_reqs......................: 540    8.154864/s

    EXECUTION
    iteration_duration.............: avg=15.62s min=2.94s   med=16.4s    max=26.31s p(90)=25.85s p(95)=26.19s
    iterations.....................: 45     0.679572/s
    vus............................: 5      min=1        max=19
    vus_max........................: 20     min=20       max=20

    NETWORK
    data_received..................: 7.4 MB 112 kB/s
    data_sent......................: 151 kB 2.3 kB/s




running (1m06.2s), 00/20 VUs, 45 complete and 0 interrupted iterations
default ✓ [======================================] 00/20 VUs  1m0s
ERRO[0066] thresholds on metrics 'http_req_duration' have been crossed 
```

</details>