### PR TITLE
Better manage the sign up redirect flow.

### DIFF
--- a/accounts/tests/test_signup_view.py
+++ b/accounts/tests/test_signup_view.py
@@ -39,7 +39,6 @@ class SignUpViewTests(TestCase):
             follow=True,
         )
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, "Registration")
         self.assertContains(
             response,
             (

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -1,7 +1,7 @@
 # Create your views here.
 from django.conf import settings
 from django.contrib import messages
-from django.contrib.auth import get_user_model
+from django.contrib.auth import get_user_model, REDIRECT_FIELD_NAME
 from django.contrib.auth import login
 from django.contrib.auth import logout
 from django.contrib.auth.decorators import login_required
@@ -95,7 +95,10 @@ class SignUpView(CreateView):
             "Your registration was successful. Please check "
             "your email provided for a confirmation link.",
         )
-        return reverse("signup")
+        return self.request.POST.get(
+            REDIRECT_FIELD_NAME,
+            self.request.GET.get(REDIRECT_FIELD_NAME, reverse("profile")),
+        )
 
     def form_valid(self, form):
         """sends a link for a user to activate their account after signup"""

--- a/indymeet/templates/includes/nav.html
+++ b/indymeet/templates/includes/nav.html
@@ -54,14 +54,14 @@
                 </li>
                 {% if "login" not in request.path %}
                 <li>
-                    <a class="outline-link text-gray-700 transition hover:text-ds-purple cursor-pointer" href="{% url 'login' %}?next={{request.path}}">
+                    <a class="outline-link text-gray-700 transition hover:text-ds-purple cursor-pointer" href="{% url 'login' %}?next={{ next|default_if_none:request.path}}">
                       {% trans "Login" %}
                     </a>
                 </li>
                 {% endif %}
                 {% if "signup" not in request.path %}
                 <li>
-                <a class="outline-link text-gray-700 transition hover:text-ds-purple cursor-pointer" href="{% url 'signup' %}">
+                <a class="outline-link text-gray-700 transition hover:text-ds-purple cursor-pointer" href="{% url 'signup' %}?next={{ next }}">
                       {% trans "Sign Up" %}
                     </a>
                 </li>


### PR DESCRIPTION
Then logging in, include the next redirect value in the signup link. When sign up completes, redirect to the next redirect value or the profile page.

Closes #631