### PR TITLE
Move the application email logic to the background task processor

### DIFF
--- a/home/models/survey.py
+++ b/home/models/survey.py
@@ -192,12 +192,18 @@ class UserSurveyResponse(BaseModel):
         return settings.BASE_URL + self.get_absolute_url()
 
     def send_created_notification(self):
-        from home.tasks.survey_notifications import send_application_created_notification
+        from home.tasks.survey_notifications import (
+            send_application_created_notification,
+        )
+
         if session := self.survey.session:
             send_application_created_notification(self, session)
 
     def send_updated_notification(self):
-        from home.tasks.survey_notifications import send_application_updated_notification
+        from home.tasks.survey_notifications import (
+            send_application_updated_notification,
+        )
+
         if session := self.survey.session:
             send_application_updated_notification(self, session)
 

--- a/home/tasks/survey_notifications.py
+++ b/home/tasks/survey_notifications.py
@@ -3,7 +3,9 @@ from home import email
 from home.models import UserSurveyResponse, Session
 
 
-def _send_application_notification(email_template: str, survey_response: UserSurveyResponse, session: Session):
+def _send_application_notification(
+    email_template: str, survey_response: UserSurveyResponse, session: Session
+):
     """Send an email to the user about the application."""
     availability, _ = UserAvailability.objects.get_or_create(user=survey_response.user)
     context = {
@@ -20,10 +22,16 @@ def _send_application_notification(email_template: str, survey_response: UserSur
         context=context,
     )
 
-def send_application_created_notification(survey_response: UserSurveyResponse, session: Session):
+
+def send_application_created_notification(
+    survey_response: UserSurveyResponse, session: Session
+):
     """Send an email to the user about the created application."""
     _send_application_notification("application_created", survey_response, session)
 
-def send_application_updated_notification(survey_response: UserSurveyResponse, session: Session):
+
+def send_application_updated_notification(
+    survey_response: UserSurveyResponse, session: Session
+):
     """Send an email to the user about the updated application."""
     _send_application_notification("application_updated", survey_response, session)


### PR DESCRIPTION
This removes another bottleneck for handling increased numbers of applicants.