### PR TITLE
Expose previously waitlisted users on form team view.

### DIFF
--- a/home/dataclasses.py
+++ b/home/dataclasses.py
@@ -23,6 +23,7 @@ class ApplicantData:
     current_team: Team | None
     current_role: str | None
     is_waitlisted: bool
+    previously_waitlisted: bool
     previous_application_count: int
     previous_avg_score: float | None
     has_availability: bool

--- a/home/filters.py
+++ b/home/filters.py
@@ -57,6 +57,11 @@ class ApplicantFilterSet(django_filters.FilterSet):
         label="Show only waitlisted applicants",
         widget=forms.CheckboxInput(attrs={"class": "form-checkbox"}),
     )
+    show_previously_waitlisted_only = BooleanFilter(
+        method="filter_previously_waitlisted_only",
+        label="Show only previously waitlisted applicants",
+        widget=forms.CheckboxInput(attrs={"class": "form-checkbox"}),
+    )
 
     overlap_with_navigators = django_filters.ModelChoiceFilter(
         queryset=Team.objects.none(),
@@ -134,4 +139,13 @@ class ApplicantFilterSet(django_filters.FilterSet):
         if value:
             # Get user IDs that are waitlisted for this session
             return queryset.filter(annotated_is_waitlisted=True)
+        return queryset
+
+    def filter_previously_waitlisted_only(
+        self, queryset: QuerySet, name: str, value: bool
+    ) -> QuerySet:
+        """Show only previously waitlisted applicants."""
+        if value:
+            # Get user IDs that are waitlisted for this session
+            return queryset.filter(annotated_previously_waitlisted=True)
         return queryset

--- a/home/managers.py
+++ b/home/managers.py
@@ -265,9 +265,14 @@ class UserSurveyResponseQuerySet(QuerySet):
         """
         Annotate the response with the user's waitlist membership.
         """
+        from home.models import Waitlist
+
         return self.annotate(
             annotated_is_waitlisted=Exists(
                 session.waitlist_entries.filter(user=OuterRef("user"))
+            ),
+            annotated_previously_waitlisted=Exists(
+                Waitlist.objects.filter(~Q(session=session), user=OuterRef("user"))
             ),
         )
 

--- a/home/templates/admin/team_formation.html
+++ b/home/templates/admin/team_formation.html
@@ -156,6 +156,7 @@
                                 {% trans "Prev Apps" %}
                             </th>
                             <th title="{% trans 'Has availability data' %}">{% trans "Avail" %}</th>
+                            <th>{% trans "Previously Waitlisted" %}</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -218,6 +219,7 @@
                                     <span class="no-availability">✗ No availability</span>
                                 {% endif %}
                             </td>
+                            <td>{{ applicant.previously_waitlisted|yesno }}</td>
                         </tr>
                         {% endfor %}
                     </tbody>

--- a/home/tests/test_waitlist_filters.py
+++ b/home/tests/test_waitlist_filters.py
@@ -171,3 +171,66 @@ class WaitlistFilterTestCase(TestCase):
         # Should only include user1 for session2
         self.assertIn(self.user1.id, user_ids)
         self.assertEqual(len(user_ids), 1)
+
+
+class PreviouslyWaitlistedFilterTestCase(TestCase):
+    """Test previously waitlisted filtering in ApplicantFilterSet."""
+
+    def setUp(self):
+        """Create test data with users waitlisted in different sessions."""
+        self.current_session = SessionFactory()
+        self.current_survey = SurveyFactory(session=self.current_session)
+        self.current_session.application_survey = self.current_survey
+        self.current_session.save()
+
+        self.previous_session = SessionFactory()
+
+        self.user_previously_waitlisted = UserFactory()
+        self.user_currently_waitlisted = UserFactory()
+        self.user_both_waitlisted = UserFactory()
+        self.user_never_waitlisted = UserFactory()
+
+        # Create survey responses for current session
+        for user in [
+            self.user_previously_waitlisted,
+            self.user_currently_waitlisted,
+            self.user_both_waitlisted,
+            self.user_never_waitlisted,
+        ]:
+            UserSurveyResponse.objects.create(user=user, survey=self.current_survey)
+
+        # user_previously_waitlisted: only on previous session waitlist
+        Waitlist.objects.create(
+            user=self.user_previously_waitlisted, session=self.previous_session
+        )
+
+        # user_currently_waitlisted: only on current session waitlist
+        Waitlist.objects.create(
+            user=self.user_currently_waitlisted, session=self.current_session
+        )
+
+        # user_both_waitlisted: on both waitlists
+        Waitlist.objects.create(
+            user=self.user_both_waitlisted, session=self.previous_session
+        )
+        Waitlist.objects.create(
+            user=self.user_both_waitlisted, session=self.current_session
+        )
+
+    def test_show_previously_waitlisted_only_filter(self):
+        """Filter returns users waitlisted in sessions other than current."""
+        queryset = UserSurveyResponse.objects.with_full_team_formation_data(
+            self.current_session
+        )
+        filterset = ApplicantFilterSet(
+            data={"show_previously_waitlisted_only": True},
+            queryset=queryset,
+            session=self.current_session,
+        )
+
+        user_ids = [r.user_id for r in filterset.qs]
+
+        self.assertIn(self.user_previously_waitlisted.id, user_ids)
+        self.assertIn(self.user_both_waitlisted.id, user_ids)
+        self.assertNotIn(self.user_currently_waitlisted.id, user_ids)
+        self.assertNotIn(self.user_never_waitlisted.id, user_ids)

--- a/home/views/team_formation.py
+++ b/home/views/team_formation.py
@@ -12,7 +12,7 @@ from django.contrib import messages
 from django.contrib.admin.views.decorators import staff_member_required
 from django.contrib.auth.decorators import permission_required
 from django.core.paginator import Paginator
-from django.db.models import Prefetch
+from django.db.models import Prefetch, F
 from django.http import HttpRequest, HttpResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
@@ -229,8 +229,6 @@ def get_filtered_applicants(
     # Apply database-level sorting
     # Nulls always go last regardless of sort order using Django's nulls_last/nulls_first
     if sort_by in ["score", "selection_rank", "annotated_previous_application_count"]:
-        from django.db.models import F
-
         order_field = F(sort_by)
         if sort_order == "desc":
             applicants_qs = applicants_qs.order_by(order_field.desc(nulls_last=True))
@@ -283,6 +281,7 @@ def get_filtered_applicants(
                 current_team=current_team,
                 current_role=current_role,
                 is_waitlisted=response.annotated_is_waitlisted,
+                previously_waitlisted=response.annotated_previously_waitlisted,
                 previous_application_count=response.annotated_previous_application_count,
                 previous_avg_score=prev_avg_score,
                 has_availability=has_availability,


### PR DESCRIPTION
This adds the previously waitlisted annotated value as a column on the table and allows filtering on it in the form.

### Original
<img width="1362" height="892" alt="Screenshot from 2026-01-29 17-31-59" src="https://github.com/user-attachments/assets/b4808966-94a5-413d-af95-91a442f5ef3b" />

### With Previously Waitlisted column and filtering field
<img width="1362" height="892" alt="Screenshot from 2026-01-29 17-31-44" src="https://github.com/user-attachments/assets/20bd3bcf-93f7-45f0-a3da-d4995e8773f5" />
