### PR TITLE
Update the compare availability page to better support timezones.

### DIFF
--- a/home/availability.py
+++ b/home/availability.py
@@ -78,22 +78,38 @@ class AvailabilityWindow:
         Returns:
             UTC datetime for the start of this availability window
         """
-        today = datetime.now().date()
-        days_until_sunday = (6 - today.weekday()) % 7
-        if days_until_sunday == 0:
-            days_until_sunday = 7
-        next_sunday = today + timedelta(days=days_until_sunday)
+        return slot_to_datetime(self.slot_range[0])
 
-        start_slot = self.slot_range[0]
-        day_offset = int(start_slot // 24)
-        hour_in_day = start_slot % 24
-        hours = int(hour_in_day)
-        minutes = int((hour_in_day % 1) * 60)
 
-        target_date = next_sunday + timedelta(days=day_offset)
-        return datetime.combine(target_date, datetime.min.time()).replace(
-            hour=hours, minute=minutes
-        )
+def slot_to_datetime(slot: float) -> datetime:
+    """
+    Convert a slot value to a datetime using the next Sunday as a reference date.
+
+    This creates a concrete datetime that can be used with templatetags like
+    time_is_link. The date is arbitrary (next Sunday from today) since
+    availability is weekly and recurring.
+
+    Args:
+        slot: Time slot value (0.0 = Sunday 00:00, 167.5 = Saturday 23:30)
+
+    Returns:
+        A datetime for the given slot, anchored to the upcoming week
+    """
+    today = datetime.now().date()
+    days_until_sunday = (6 - today.weekday()) % 7
+    if days_until_sunday == 0:
+        days_until_sunday = 7
+    next_sunday = today + timedelta(days=days_until_sunday)
+
+    day_offset = int(slot // 24)
+    hour_in_day = slot % 24
+    hours = int(hour_in_day)
+    minutes = int((hour_in_day % 1) * 60)
+
+    target_date = next_sunday + timedelta(days=day_offset)
+    return datetime.combine(target_date, datetime.min.time()).replace(
+        hour=hours, minute=minutes
+    )
 
 
 def _convert_to_12hour_format(hour_24: int) -> tuple[int, str]:

--- a/home/templates/home/_compare_availability_grid.html
+++ b/home/templates/home/_compare_availability_grid.html
@@ -1,0 +1,128 @@
+{% load i18n email_tags %}
+
+{% if selected_users %}
+<!-- Timezone and Legend -->
+<div class="flex items-center justify-between mb-3">
+    <span class="text-sm text-gray-600">
+        {% trans "Timezone:" %} <span x-text="timezone" class="font-bold"></span>
+    </span>
+    <div class="flex items-center gap-2">
+        <span class="text-xs text-gray-500">{% trans "Legend:" %}</span>
+        <span class="inline-flex items-center gap-1">
+            <span class="w-4 h-4 rounded border border-gray-200 bg-ds-purple"></span>
+            <span class="text-xs">{% trans "All available" %}</span>
+        </span>
+        <span class="inline-flex items-center gap-1">
+            <span class="w-4 h-4 rounded bg-gray-50 border border-gray-200"></span>
+            <span class="text-xs">{% trans "None available" %}</span>
+        </span>
+    </div>
+</div>
+
+<!-- Main Content Area -->
+<div class="flex flex-col lg:flex-row gap-6">
+    <!-- Grid -->
+    <div class="flex-grow">
+        <div class="overflow-x-auto">
+            <table id="availability-grid" class="w-full border-collapse">
+                <thead>
+                    <tr>
+                        <th class="bg-gray-50 border border-gray-200 p-1 w-16"></th>
+                        <th class="bg-gray-50 p-2 font-semibold text-xs text-center border border-b-2 border-gray-200">{% trans "Sun" %}</th>
+                        <th class="bg-gray-50 p-2 font-semibold text-xs text-center border border-b-2 border-gray-200">{% trans "Mon" %}</th>
+                        <th class="bg-gray-50 p-2 font-semibold text-xs text-center border border-b-2 border-gray-200">{% trans "Tue" %}</th>
+                        <th class="bg-gray-50 p-2 font-semibold text-xs text-center border border-b-2 border-gray-200">{% trans "Wed" %}</th>
+                        <th class="bg-gray-50 p-2 font-semibold text-xs text-center border border-b-2 border-gray-200">{% trans "Thu" %}</th>
+                        <th class="bg-gray-50 p-2 font-semibold text-xs text-center border border-b-2 border-gray-200">{% trans "Fri" %}</th>
+                        <th class="bg-gray-50 p-2 font-semibold text-xs text-center border border-b-2 border-gray-200">{% trans "Sat" %}</th>
+                    </tr>
+                </thead>
+                <tbody @mouseleave="hoveredSlot = null;
+                    if (!fixedSlot) { activeDisplayTime = ''; activeTimeIsUrl = ''; }">
+                    {% for row in grid_rows %}
+                    <tr>
+                        {% if row.show_time_label %}
+                        <th rowspan="2" class="border border-gray-200 text-xs text-right pr-2 bg-gray-50">
+                            {{ row.time_label }}
+                        </th>
+                        {% endif %}
+                        {% for cell in row.cells %}
+                        <td class="time-slot h-4 border border-gray-200 cursor-pointer"
+                            :style="{
+                                ...getCellStyle('{{ cell.slot_key }}', '{{ cell.color|default:'' }}'),
+                                ...(fixedSlot === '{{ cell.slot_key }}' ? {
+                                    outline: '3px solid #7c3aed',
+                                    outlineOffset: '-1px',
+                                    position: 'relative',
+                                    zIndex: 10
+                                } : {})
+                            }"
+                            title="{{ cell.available_count }}/{{ cell.total_count }} {% trans 'available' %}"
+                            data-display-time="{{ cell.display_time }}"
+                            data-time-is-url="{{ cell.utc_datetime|time_is_link }}"
+                            @mouseenter="hoveredSlot = '{{ cell.slot_key }}';
+                                if (!fixedSlot) {
+                                    activeDisplayTime = $event.target.dataset.displayTime;
+                                    activeTimeIsUrl = $event.target.dataset.timeIsUrl;
+                                }"
+                            @click="
+                                if (fixedSlot === '{{ cell.slot_key }}') {
+                                    fixedSlot = null;
+                                    activeDisplayTime = '';
+                                    activeTimeIsUrl = '';
+                                } else {
+                                    fixedSlot = '{{ cell.slot_key }}';
+                                    activeDisplayTime = $event.target.dataset.displayTime;
+                                    activeTimeIsUrl = $event.target.dataset.timeIsUrl;
+                                }">
+                        </td>
+                        {% endfor %}
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    </div>
+
+    <!-- Users Panel -->
+    <div class="w-full lg:w-64 flex-shrink-0">
+        <div class="bg-white border border-gray-200 rounded-lg p-4 sticky top-4">
+            <div x-show="activeDisplayTime" x-cloak class="mb-3 p-2 bg-purple-50 rounded border border-purple-200 text-sm">
+                <div class="flex items-center justify-between">
+                    <span class="font-semibold text-purple-900" x-text="activeDisplayTime"></span>
+                    <button x-show="fixedSlot"
+                            @click="fixedSlot = null; activeDisplayTime = ''; activeTimeIsUrl = '';"
+                            class="text-purple-400 hover:text-purple-700 ml-2 cursor-pointer text-lg leading-none font-bold"
+                            title="{% trans 'Unpin time slot' %}">
+                        &times;
+                    </button>
+                </div>
+                <a :href="activeTimeIsUrl"
+                   target="_blank"
+                   rel="noopener noreferrer"
+                   class="block text-purple-600 hover:text-purple-800 text-xs mt-1 underline">
+                    {% trans "View on time.is" %} &rarr;
+                </a>
+            </div>
+            <h3 class="font-bold text-gray-900 mb-3">{% trans "Selected Users" %}</h3>
+            <div class="space-y-2">
+                <template x-for="user in users" :key="user.id">
+                    <div class="user-card p-2 rounded border border-gray-100 cursor-pointer"
+                         :class="{ 'unavailable': isUnavailable(user.id), 'bg-purple-100 border-purple-300': hoveredUser === user.id }"
+                         @mouseenter="hoveredUser = user.id"
+                         @mouseleave="hoveredUser = null">
+                        <span class="user-name text-sm text-gray-900 truncate" x-text="user.display_name"></span>
+                    </div>
+                </template>
+            </div>
+        </div>
+    </div>
+</div>
+
+{{ slot_availabilities|json_script:"slot-availabilities" }}
+{{ selected_users|json_script:"selected-users" }}
+{% else %}
+<div class="text-center py-12 text-gray-500">
+    <p>{% trans "Select users above and click Apply to compare availability." %}</p>
+</div>
+{% endif %}

--- a/home/templates/home/compare_availability.html
+++ b/home/templates/home/compare_availability.html
@@ -96,107 +96,54 @@
             </div>
         </form>
 
-        {% if selected_users %}
-        <!-- Timezone and Legend -->
-        <div class="flex items-center justify-between mb-3">
-            <span class="text-sm text-gray-600">
-                {% trans "Timezone:" %} <span x-text="timezone" class="font-bold"></span>
-            </span>
-            <div class="flex items-center gap-2">
-                <span class="text-xs text-gray-500">{% trans "Legend:" %}</span>
-                <span class="inline-flex items-center gap-1">
-                    <span class="w-4 h-4 rounded border border-gray-200 bg-ds-purple"></span>
-                    <span class="text-xs">{% trans "All available" %}</span>
-                </span>
-                <span class="inline-flex items-center gap-1">
-                    <span class="w-4 h-4 rounded bg-gray-50 border border-gray-200"></span>
-                    <span class="text-xs">{% trans "None available" %}</span>
-                </span>
+        {% comment %}
+            The grid is loaded via htmx so we can inject the browser's UTC offset
+            (not available server-side) into the request via hx-vals.
+            After htmx settles the response, we hydrate Alpine.js state from the
+            JSON script tags rendered by the grid partial and reset any pinned
+            slot since the grid contents have changed.
+        {% endcomment %}
+        <div id="availability-grid-container"
+             hx-get="{% url 'compare_availability_grid' %}?{{ request.GET.urlencode }}"
+             hx-trigger="load"
+             hx-vals='js:{"offset": -new Date().getTimezoneOffset() / 60}'
+             hx-swap="innerHTML"
+             hx-disinherit="*"
+             @htmx:after-settle="
+                 const sa = document.getElementById('slot-availabilities');
+                 const su = document.getElementById('selected-users');
+                 if (sa) slotAvailabilities = JSON.parse(sa.textContent);
+                 if (su) users = JSON.parse(su.textContent);
+                 fixedSlot = null;
+                 activeDisplayTime = '';
+                 activeTimeIsUrl = '';
+             ">
+            <div class="text-center py-12 text-gray-500">
+                <p>{% trans "Loading availability..." %}</p>
             </div>
         </div>
-
-        <!-- Main Content Area -->
-        <div class="flex flex-col lg:flex-row gap-6">
-            <!-- Grid -->
-            <div class="flex-grow">
-                <div class="overflow-x-auto">
-                    <table id="availability-grid" class="w-full border-collapse">
-                        <thead>
-                            <tr>
-                                <th class="bg-gray-50 border border-gray-200 p-1 w-16"></th>
-                                <th class="bg-gray-50 p-2 font-semibold text-xs text-center border border-b-2 border-gray-200">{% trans "Sun" %}</th>
-                                <th class="bg-gray-50 p-2 font-semibold text-xs text-center border border-b-2 border-gray-200">{% trans "Mon" %}</th>
-                                <th class="bg-gray-50 p-2 font-semibold text-xs text-center border border-b-2 border-gray-200">{% trans "Tue" %}</th>
-                                <th class="bg-gray-50 p-2 font-semibold text-xs text-center border border-b-2 border-gray-200">{% trans "Wed" %}</th>
-                                <th class="bg-gray-50 p-2 font-semibold text-xs text-center border border-b-2 border-gray-200">{% trans "Thu" %}</th>
-                                <th class="bg-gray-50 p-2 font-semibold text-xs text-center border border-b-2 border-gray-200">{% trans "Fri" %}</th>
-                                <th class="bg-gray-50 p-2 font-semibold text-xs text-center border border-b-2 border-gray-200">{% trans "Sat" %}</th>
-                            </tr>
-                        </thead>
-                        <tbody @mouseleave="hoveredSlot = null">
-                            {% for row in grid_rows %}
-                            <tr>
-                                {% if row.show_time_label %}
-                                <th rowspan="2" class="border border-gray-200 text-xs text-right pr-2 bg-gray-50">
-                                    {{ row.time_label }}
-                                </th>
-                                {% endif %}
-                                {% for cell in row.cells %}
-                                <td class="time-slot h-4 border border-gray-200 cursor-pointer"
-                                    :style="getCellStyle('{{ cell.slot_key }}', '{{ cell.color|default:'' }}')"
-                                    title="{{ cell.available_count }}/{{ cell.total_count }} {% trans 'available' %}"
-                                    @mouseenter="hoveredSlot = '{{ cell.slot_key }}'">
-                                </td>
-                                {% endfor %}
-                            </tr>
-                            {% endfor %}
-                        </tbody>
-                    </table>
-                </div>
-            </div>
-
-            <!-- Users Panel -->
-            <div class="w-full lg:w-64 flex-shrink-0">
-                <div class="bg-white border border-gray-200 rounded-lg p-4 sticky top-4">
-                    <h3 class="font-bold text-gray-900 mb-3">{% trans "Selected Users" %}</h3>
-                    <div class="space-y-2">
-                        <template x-for="user in users" :key="user.id">
-                            <div class="user-card p-2 rounded border border-gray-100 cursor-pointer"
-                                 :class="{ 'unavailable': isUnavailable(user.id), 'bg-purple-100 border-purple-300': hoveredUser === user.id }"
-                                 @mouseenter="hoveredUser = user.id"
-                                 @mouseleave="hoveredUser = null">
-                                <span class="user-name text-sm text-gray-900 truncate" x-text="user.display_name"></span>
-                            </div>
-                        </template>
-                    </div>
-                </div>
-            </div>
-        </div>
-        {% else %}
-        <div class="text-center py-12 text-gray-500">
-            <p>{% trans "Select users above and click Apply to compare availability." %}</p>
-        </div>
-        {% endif %}
     </div>
 </main>
-{{ slot_availabilities|json_script:"slot-availabilities" }}
-{{ selected_users|json_script:"selected-users" }}
-
 <script>
 function availabilityGrid() {
-    const slotAvailabilities = JSON.parse(document.getElementById('slot-availabilities').textContent);
-    const users = JSON.parse(document.getElementById('selected-users').textContent);
     return {
-        slotAvailabilities: slotAvailabilities,
-        users: users,
+        slotAvailabilities: {},
+        users: [],
         hoveredSlot: null,
+        fixedSlot: null,
         hoveredUser: null,
+        activeDisplayTime: '',
+        activeTimeIsUrl: '',
         timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
         offsetHours: -new Date().getTimezoneOffset() / 60,
 
+        get activeSlot() {
+            return this.fixedSlot || this.hoveredSlot;
+        },
+
         isUnavailable(userId) {
-            if (this.hoveredSlot === null) return false;
-            const available = this.slotAvailabilities[this.hoveredSlot] || [];
+            if (this.activeSlot === null) return false;
+            const available = this.slotAvailabilities[this.activeSlot] || [];
             return !available.includes(userId);
         },
 

--- a/home/urls.py
+++ b/home/urls.py
@@ -1,7 +1,10 @@
 from django.urls import path
 from django.views.generic import TemplateView
 
-from home.views.compare_availability import compare_availability
+from home.views.compare_availability import (
+    compare_availability,
+    compare_availability_grid,
+)
 from home.views.events import EventDetailView, EventListView, event_calendar
 from home.views.membership_acceptance import accept_membership_view
 from home.views.resources import resource_link
@@ -29,6 +32,11 @@ urlpatterns = [
         "compare-availability/",
         compare_availability,
         name="compare_availability",
+    ),
+    path(
+        "compare-availability/grid/",
+        compare_availability_grid,
+        name="compare_availability_grid",
     ),
     path("events/", EventListView.as_view(), name="event_list"),
     path(


### PR DESCRIPTION
- Shows the time being hovered with a link to time.is
- Clicking on a time pins it
- Loads up the grid via AJAX, well HTMX
- Pinned times are highlighted and can be dismissed by clicking again or X-ing on the time

Fixes #670

<img width="965" height="634" alt="Screenshot from 2026-02-03 09-51-30" src="https://github.com/user-attachments/assets/fcbf6f4a-d6a9-467e-bb6e-a71b4d0747ea" />
