### PR TITLE
feat: created eye toggle for password input

### DIFF
--- a/indymeet/templates/forms/form.html
+++ b/indymeet/templates/forms/form.html
@@ -12,11 +12,11 @@
     {% if field|field_type == 'booleanfield' %} {{ field|add_class:"rounded border-gray-300 text-indigo-600 shadow-sm focus:border-indigo-300 focus:ring focus:ring-offset-0 focus:ring-indigo-200 focus:ring-opacity-50 read-only:text-slate-700" }}
     <!-- Password field with toggle visibility -->
     {% elif field.field.widget.input_type == 'password' %}
-        <div class="flex">
-            {{ field|add_class:"password-input block rounded-lg border-gray-300 shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50 mb-2 "|attr:"placeholder:" }}
+        <div class="flex mb-2">
+            {{ field|add_class:"password-input block rounded-lg border-gray-300 shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50"|attr:"placeholder:" }}
             <button type="button"
                     onclick="togglePassword()"
-                    class="text-gray-600 -ml-[30px] hover:text-gray-800">
+                    class="text-gray-600 text-center -ml-[30px] hover:text-gray-800">
                 <i class="eye fa-solid fa-eye"> </i>
             </button>
         </div>


### PR DESCRIPTION
I updated the password input to include an eye button. This changes the login and registration pages.

Fixes #630 


<img width="407" height="503" alt="Screenshot 2026-02-05 alle 22 54 58" src="https://github.com/user-attachments/assets/0fe78d78-1f8b-4956-92be-b9706836f66b" />
<img width="1419" height="783" alt="Screenshot 2026-02-05 alle 22 55 31" src="https://github.com/user-attachments/assets/a348e0c9-1ca3-4126-826e-443bb3775761" />

