### PR TITLE
Form layout refactor 

### DIFF
--- a/indymeet/templates/forms/form.html
+++ b/indymeet/templates/forms/form.html
@@ -1,7 +1,7 @@
 {% load widget_tweaks %}
-<div class="grid grid-cols-1 gap-6 mb-2">
+<div class="mb-2 grid grid-cols-1 gap-6">
   {% if form.non_field_errors %}
-  <div class="bg-red-100 border-l-4 border-red-500 text-red-700 p-4 mb-6" role="alert">
+  <div class="mb-6 border-l-4 border-red-500 bg-red-100 p-4 text-red-700" role="alert">
     <ul>{{ form.non_field_errors.as_ul }}</ul>
   </div>
   {% endif %}
@@ -12,16 +12,16 @@
     {% if field|field_type == 'booleanfield' %} {{ field|add_class:"rounded border-gray-300 text-indigo-600 shadow-sm focus:border-indigo-300 focus:ring focus:ring-offset-0 focus:ring-indigo-200 focus:ring-opacity-50 read-only:text-slate-700" }}
     <!-- Password field with toggle visibility -->
     {% elif field.field.widget.input_type == 'password' %}
-        <div class="flex mb-2">
-            {{ field|add_class:"password-input block rounded-lg border-gray-300 shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50"|attr:"placeholder:" }}
+        <div class="mb-2 flex">
+            {{ field|add_class:"password-input block w-full rounded-lg border-gray-300 shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50"|attr:"placeholder:" }}
             <button type="button"
                     onclick="togglePassword(this)"
-                    class="text-gray-600 text-center -ml-[30px] hover:text-gray-800">
+                    class="text-center text-gray-600 -ml-[30px] hover:text-gray-800">
                 <i class="eye fa-solid fa-eye"> </i>
             </button>
         </div>
     {% else %}
-    {{ field|add_class:"mt-1 block rounded-lg border-gray-300 shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50 disabled:bg-slate-50 disabled:text-slate-700 disabled:border-slate-200"|attr:"placeholder:" }}
+    {{ field|add_class:"mt-1 block rounded-lg w-full border-gray-300 shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50 disabled:bg-slate-50 disabled:text-slate-700 disabled:border-slate-200"|attr:"placeholder:" }}
     {% endif %}
     {% if field.help_text %}<div class="text-gray-500"{% if field.auto_id %} id="{{ field.auto_id }}_helptext"{% endif %}>{{ field.help_text|safe }}</div>{% endif %}
     {% if field.errors %}<ul class="text-red-700">{% for error in field.errors %}<li>{{ error }}</li>{% endfor %}</ul>{% endif %}

--- a/indymeet/templates/registration/login.html
+++ b/indymeet/templates/registration/login.html
@@ -10,37 +10,40 @@
 {% endblock extra_css %}
 
 {% block content %}
-<main class="section my-3 mx-5">
-    <div class="section-container">
+    <main class="mx-auto max-w-xl px-2 py-8 md:px-4">
         {% if next %}
-            <div class="row pt-4 pb-4">
-                <div class="col">
+            <div class="mb-4 border-l-4 border-red-500 bg-red-100 p-4 text-red-700">
                 {% if user.is_authenticated %}
                     <p>{% translate "Your account doesn't have access to this page. To proceed, please login with an account that has access." %}</p>
                 {% else %}
                     <p>{% translate "Please login to see this page." %}</p>
                 {% endif %}
-                </div>
             </div>
         {% endif %}
 
-        <div class="row">
-          <div class="col">
-            <form method="post">
-              {% csrf_token %}
-
-              {{ form }}
-              <button type="submit" class="action-button">Login</button>
-              <input type="hidden" name="next" value="{{ next }}">
-            </form>
-          </div>
-          <div class="row pt-4 pb-4">
-            <div class="col">
-                <p>{% translate "Forgotten your password?" %} <a href="{% url 'password_reset' %}" class="text-ds-purple hover:underline">{% translate "Reset password." %}</a></p>
-            </div>
-          </div>
-          <div class="col"></div>
+        <!-- Header -->
+        <div class="mb-10 text-center">
+            <h1 class="mb-2 text-5xl font-bold text-gray-800">Login</h1>
         </div>
-    </div>
-</main>
+        <!-- Box with shadow-->
+        <div class="mb-4 rounded-xl md:mb-8 md:p-16 md:shadow-lg">
+            <form method="post">
+                {% csrf_token %}
+
+                {{ form }}
+                <button type="submit" class="action-button">Login</button>
+                <input type="hidden" name="next" value="{{ next }}">
+            </form>
+        </div>
+        <div class="flex flex-col gap-1 md:flex-row">
+            <div>
+                <p>{% translate "Forgotten your password?" %} </p>
+            </div>
+            <div>
+                <p><a href="{% url 'password_reset' %}"
+                      class="text-ds-purple hover:underline">{% translate "Reset password." %}</a></p>
+            </div>
+        </div>
+    </main>
+
 {% endblock content %}

--- a/indymeet/templates/registration/password_change_form.html
+++ b/indymeet/templates/registration/password_change_form.html
@@ -10,19 +10,20 @@
 {% endblock extra_css %}
 
 {% block content %}
-<main class="section my-3 mx-5">
-    <div class="section-container">
-        <h1 class="text-5xl mb-6">{% translate "Update password" %}</h1>
-        <div class="row">
-          <div class="col">
+<main class="mx-auto max-w-3xl px-2 py-8 md:px-4">
+    <div class="mb-12 md:mb-6">
+        <h1 class="mb-6 text-center text-5xl">{% translate "Update password" %}</h1>
+    </div>
+
+    <!-- Box with shadow-->
+    <div class="mb-4 md:mb-8 md:rounded-xl md:p-16 md:shadow-lg">
             <form method="post">
               {% csrf_token %}
+
+
               {{ form }}
               <button type="submit" class="action-button">{% translate "Update password" %}</button>
             </form>
-          </div>
-          <div class="col"></div>
-        </div>
     </div>
 </main>
 {% endblock content %}

--- a/indymeet/templates/registration/password_reset_confirm.html
+++ b/indymeet/templates/registration/password_reset_confirm.html
@@ -10,26 +10,25 @@
 {% endblock extra_css %}
 
 {% block content %}
-<main class="section my-3 mx-5">
-    <div class="section-container">
+<main class="mx-auto max-w-3xl px-2 py-8 md:px-4">
+    <div class="mb-10 text-center">
         <h1 class="text-5xl">{% translate "Reset password" %}</h1>
+    </div>
         {% if validlink %}
-
-        <div class="row pt-4 pb-4">
-          <div class="col">
+        <!-- Box with shadow-->
+        <div class="mb-4 md:mb-8 md:rounded-xl md:p-16 md:shadow-lg">
             <form method="post">
               {% csrf_token %}
 
               {{ form }}
-              <button type="submit" class="action-button">{% translate "Change password" %}</button>
+              <button type="submit" class="mt-2 action-button">{% translate "Change password" %}</button>
 
             </form>
-          </div>
-          <div class="col"></div>
         </div>
         {% else %}
+            <div class="mb-10 text-center">
         <p>{% translate "The password reset link was invalid, possibly because it has already been used.  Please request a new password reset." %}</p>
+            </div>
         {% endif %}
-    </div>
 </main>
 {% endblock content %}

--- a/indymeet/templates/registration/password_reset_form.html
+++ b/indymeet/templates/registration/password_reset_form.html
@@ -6,29 +6,25 @@
 
 
 {% block extra_css %}
-<link rel="stylesheet" href="{% static 'css/registration.css' %}">
+    <link rel="stylesheet" href="{% static 'css/registration.css' %}">
 {% endblock extra_css %}
 
 {% block content %}
-<main class="section my-3 mx-5">
-    <div class="section-container">
-        <h1 class="text-5xl">{% translate "Reset password" %}</h1>
-        <div class="row pt-4 pb-4">
-          <div class="col">
-            <p>{% translate "Forgotten your password? Enter your email address below, and we’ll email instructions for setting a new one." %}</p>
-          </div>
+    <main class="mx-auto max-w-xl px-2 py-8 md:px-4">
+        <div class="mb-12 md:mb-6">
+            <h1 class="mb-2 text-center text-4xl font-bold text-gray-800">{% translate "Reset password" %}</h1>
+                <p class="text-lg text-gray-600">{% translate "Forgotten your password? Enter your email address below, and we’ll email instructions for setting a new one." %}</p>
+
         </div>
 
-        <div class="row">
-          <div class="col">
+        <div class="mb-4 rounded-xl md:mb-8 md:p-10 md:shadow-lg">
             <form method="post">
-              {% csrf_token %}
-              {{ form }}
-              <button type="submit" class="action-button">{% translate "Rest password" %}</button>
+                {% csrf_token %}
+                <div class="mb-4">
+                    {{ form }}
+                </div>
+                <button type="submit" class="mt-2 action-button">{% translate "Reset password" %}</button>
             </form>
-          </div>
-          <div class="col"></div>
         </div>
-    </div>
-</main>
+    </main>
 {% endblock content %}

--- a/indymeet/templates/registration/signup.html
+++ b/indymeet/templates/registration/signup.html
@@ -10,17 +10,15 @@
 {% endblock extra_css %}
 
 {% block content %}
-<main class="section my-3 mx-5">
-    <div class="section-container">
-        <h1 class="text-5xl">{% translate "Registration" %}</h1>
-        <div class="row pt-4 pb-4">
-          <div class="col">
-            <p>{% translate "Sign up to keep up with all things Djangonaut Space!" %}</p>
-          </div>
+<main class="mx-auto max-w-3xl px-2 py-8 md:px-4">
+    <div class="mb-10 text-center">
+        <h1 class="mb-2 text-5xl">{% translate "Registration" %}</h1>
+
+            <p class="text-lg text-gray-600">{% translate "Sign up to keep up with all things Djangonaut Space!" %}</p>
         </div>
 
-        <div class="row">
-          <div class="col">
+        <!-- Box with shadow-->
+        <div class="mb-4 md:mb-8 md:rounded-xl md:p-16 md:shadow-lg">
             <form method="post">
               {% csrf_token %}
 
@@ -29,8 +27,5 @@
 
             </form>
           </div>
-          <div class="col"></div>
-        </div>
-    </div>
 </main>
 {% endblock content %}

--- a/indymeet/templates/registration/update_user.html
+++ b/indymeet/templates/registration/update_user.html
@@ -10,22 +10,19 @@
 {% endblock extra_css %}
 
 {% block content %}
-<main class="section my-3 mx-5">
-    <div class="section-container">
-        <h1 class="text-5xl mb-6">{% translate "Update Profile Info" %}</h1>
+<main class="mx-auto max-w-3xl px-2 py-8 md:px-4">
+    <div class="mb-12 md:mb-6">
+        <h1 class="mb-6 text-center text-5xl">{% translate "Update Profile Info" %}</h1>
+    </div>
 
-        <div class="row ">
-          <div class="col">
+        <!-- Box with shadow-->
+        <div class="mb-4 md:mb-8 md:rounded-xl md:p-16 md:shadow-lg">
             <form method="post">
               {% csrf_token %}
-
               {{ form }}
-              <button type="submit" class="action-button mt-4">{% translate "Save" %}</button>
-              <a class="px-4 text-ds-purple hover:underline cursor-pointer" href="{% url "profile" %}"> {% trans "Cancel" %}</a>
+              <button type="submit" class="mt-4 action-button">{% translate "Save" %}</button>
+              <a class="cursor-pointer px-4 text-ds-purple hover:underline" href="{% url "profile" %}"> {% trans "Cancel" %}</a>
             </form>
           </div>
-          <div class="col"></div>
-        </div>
-    </div>
 </main>
 {% endblock content %}


### PR DESCRIPTION
I updated the layout of every form available except for `update_email_subscriptions.html`, even if it's still available in the accounts urls I suspect it is not used anymore because of the adoption of Buttondown. 

<img width="1552" height="987" alt="Screenshot 2026-02-13 alle 06 52 52" src="https://github.com/user-attachments/assets/1f6ba2f6-d83b-4e70-9632-1914866888b4" />
<img width="371" height="663" alt="Screenshot 2026-02-13 alle 06 54 28" src="https://github.com/user-attachments/assets/c676ff97-d4a7-481d-9a84-171cb975fb83" />
<img width="371" height="663" alt="Screenshot 2026-02-13 alle 06 54 47" src="https://github.com/user-attachments/assets/5241e86a-9f9a-481a-a71c-4adf7bb6893c" />
<img width="1552" height="987" alt="Screenshot 2026-02-13 alle 06 54 56" src="https://github.com/user-attachments/assets/1ae0fcdb-b4ca-47ba-bb5c-a82579ff529e" />
<img width="1552" height="987" alt="Screenshot 2026-02-13 alle 06 55 18" src="https://github.com/user-attachments/assets/c4608da7-1749-4090-aea1-88d18a889604" />
<img width="1552" height="987" alt="Screenshot 2026-02-13 alle 06 55 39" src="https://github.com/user-attachments/assets/6d296f84-3b01-4bbc-a3c8-5fb9ba27da03" />
 
<img width="371" height="663" alt="Screenshot 2026-02-13 alle 06 56 30" src="https://github.com/user-attachments/assets/581d5696-89ce-4b04-a1c1-d3144dae7b29" />
<img width="1552" height="987" alt="Screenshot 2026-02-13 alle 07 01 14" src="https://github.com/user-attachments/assets/51d766ee-54a7-4c3c-9da8-da3edf9b9791" />
<img width="1552" height="987" alt="Screenshot 2026-02-13 alle 07 01 23" src="https://github.com/user-attachments/assets/1bb7f636-42a8-4398-a9b0-cd223968aa38" />
<img width="1552" height="987" alt="Screenshot 2026-02-13 alle 17 25 44" src="https://github.com/user-attachments/assets/4191bd1a-e38b-43b8-9114-fd361126aeaa" />
<img width="371" height="663" alt="Screenshot 2026-02-13 alle 17 26 03" src="https://github.com/user-attachments/assets/37c204ed-310f-45d6-ba93-cece747e95ea" />
