### PR TITLE
Allow users to reset their password with an unuseable password.

### DIFF
--- a/accounts/management/commands/notify_unusable_password_users.py
+++ b/accounts/management/commands/notify_unusable_password_users.py
@@ -1,0 +1,69 @@
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.contrib.auth.hashers import UNUSABLE_PASSWORD_PREFIX
+from django.contrib.auth.tokens import default_token_generator
+from django.core.management.base import BaseCommand
+from django.urls import reverse
+from django.utils.encoding import force_bytes
+from django.utils.http import urlsafe_base64_encode
+
+from home.email import send
+
+User = get_user_model()
+
+
+class Command(BaseCommand):
+    help = (
+        "Email active users with unusable passwords to inform them that an account "
+        "exists for their email address and explain how to set a password or delete "
+        "their account."
+    )
+
+    def add_arguments(self, parser) -> None:
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="List affected users without sending any emails.",
+        )
+
+    def handle(self, *args, **options) -> None:
+        dry_run = options["dry_run"]
+        users = User.objects.filter(
+            is_active=True,
+            password__startswith=UNUSABLE_PASSWORD_PREFIX,
+        ).iterator()
+        emails_sent = 0
+
+        for user in users:
+            if dry_run:
+                self.stdout.write(
+                    f"Would email: {user.email} ({user.get_full_name() or user.username})"
+                )
+                emails_sent += 1
+                continue
+
+            uidb64 = urlsafe_base64_encode(force_bytes(user.pk))
+            token = default_token_generator.make_token(user)
+            reset_path = reverse(
+                "password_reset_confirm",
+                kwargs={"uidb64": uidb64, "token": token},
+            )
+            send(
+                email_template="unusable_password_notification",
+                recipient_list=[user.email],
+                context={
+                    "name": user.get_full_name() or user.username,
+                    "cta_link": settings.BASE_URL + reset_path,
+                    "delete_account_url": settings.BASE_URL + reverse("delete_account"),
+                },
+            )
+            emails_sent += 1
+
+        if dry_run:
+            self.stdout.write(
+                self.style.WARNING(
+                    f"Dry run complete: {emails_sent} user(s) would be notified."
+                )
+            )
+        else:
+            self.stdout.write(self.style.SUCCESS(f"Notified {emails_sent} user(s)."))

--- a/accounts/management/commands/tests/test_notify_unusable_password_users.py
+++ b/accounts/management/commands/tests/test_notify_unusable_password_users.py
@@ -1,0 +1,93 @@
+import pytest
+from django.core import mail, management
+from django.contrib.auth import get_user_model
+
+from accounts.factories import UserFactory
+
+User = get_user_model()
+
+
+@pytest.mark.django_db
+class TestNotifyUnusablePasswordUsersCommand:
+    def test_sends_email_to_unusable_password_user(self):
+        user = UserFactory.create(is_active=True)
+        user.set_unusable_password()
+        user.save()
+
+        management.call_command("notify_unusable_password_users")
+
+        assert len(mail.outbox) == 1
+        assert mail.outbox[0].to == [user.email]
+
+    def test_email_subject(self):
+        user = UserFactory.create(is_active=True)
+        user.set_unusable_password()
+        user.save()
+
+        management.call_command("notify_unusable_password_users")
+
+        assert len(mail.outbox) == 1
+        assert (
+            mail.outbox[0].subject
+            == "A Djangonaut Space account has been created for you"
+        )
+
+    def test_email_contains_password_reset_link(self):
+        user = UserFactory.create(is_active=True)
+        user.set_unusable_password()
+        user.save()
+
+        management.call_command("notify_unusable_password_users")
+
+        assert len(mail.outbox) == 1
+        assert "/accounts/reset/" in mail.outbox[0].body
+
+    def test_email_contains_delete_account_url(self):
+        user = UserFactory.create(is_active=True)
+        user.set_unusable_password()
+        user.save()
+
+        management.call_command("notify_unusable_password_users")
+
+        assert len(mail.outbox) == 1
+        assert "delete" in mail.outbox[0].body
+
+    def test_skips_users_with_usable_passwords(self):
+        user = UserFactory.create(is_active=True)
+        user.set_password("strongpassword123")
+        user.save()
+
+        management.call_command("notify_unusable_password_users")
+
+        assert len(mail.outbox) == 0
+
+    def test_skips_inactive_users(self):
+        user = UserFactory.create(is_active=False)
+        user.set_unusable_password()
+        user.save()
+
+        management.call_command("notify_unusable_password_users")
+
+        assert len(mail.outbox) == 0
+
+    def test_sends_to_multiple_unusable_password_users(self):
+        for _ in range(3):
+            user = UserFactory.create(is_active=True)
+            user.set_unusable_password()
+            user.save()
+
+        management.call_command("notify_unusable_password_users")
+
+        assert len(mail.outbox) == 3
+
+    def test_dry_run_does_not_send_emails(self, capsys):
+        user = UserFactory.create(is_active=True)
+        user.set_unusable_password()
+        user.save()
+
+        management.call_command("notify_unusable_password_users", dry_run=True)
+
+        assert len(mail.outbox) == 0
+        captured = capsys.readouterr()
+        assert user.email in captured.out
+        assert "1 user(s) would be notified" in captured.out

--- a/accounts/tests/test_custom_password_reset_form.py
+++ b/accounts/tests/test_custom_password_reset_form.py
@@ -1,0 +1,49 @@
+from django.test import TestCase
+
+from accounts.factories import UserFactory
+from accounts.views import CustomPasswordResetForm
+
+
+class CustomPasswordResetFormGetUsersTests(TestCase):
+    """Tests for CustomPasswordResetForm.get_users.
+
+    The key difference from Django's base PasswordResetForm is that this
+    implementation includes users with unusable passwords, enabling password
+    resets for social auth users who have not yet set a local password.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = UserFactory.create(email="test@example.com", is_active=True)
+        cls.user.set_password("password123")
+        cls.user.save()
+
+    def _get_users(self, email: str) -> list:
+        return list(CustomPasswordResetForm().get_users(email))
+
+    def test_returns_active_user_with_matching_email(self):
+        users = self._get_users("test@example.com")
+        self.assertEqual(users, [self.user])
+
+    def test_excludes_inactive_user(self):
+        inactive_user = UserFactory.create(
+            email="inactive@example.com", is_active=False
+        )
+        users = self._get_users(inactive_user.email)
+        self.assertEqual(users, [])
+
+    def test_includes_user_with_unusable_password(self):
+        """Users with unusable passwords are included, unlike the base class."""
+        unusable_user = UserFactory.create(email="unusable@example.com", is_active=True)
+        unusable_user.set_unusable_password()
+        unusable_user.save()
+        users = self._get_users(unusable_user.email)
+        self.assertEqual(users, [unusable_user])
+
+    def test_case_insensitive_email_match(self):
+        users = self._get_users("TEST@EXAMPLE.COM")
+        self.assertEqual(users, [self.user])
+
+    def test_no_match_returns_empty(self):
+        users = self._get_users("nonexistent@example.com")
+        self.assertEqual(users, [])

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -5,6 +5,7 @@ from django.contrib.auth import get_user_model, REDIRECT_FIELD_NAME
 from django.contrib.auth import login
 from django.contrib.auth import logout
 from django.contrib.auth.decorators import login_required
+from django.contrib.auth.forms import PasswordResetForm, _unicode_ci_compare
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.auth.mixins import UserPassesTestMixin
 from django.contrib.auth.views import PasswordResetView
@@ -37,8 +38,29 @@ from .tokens import account_activation_token
 User = get_user_model()
 
 
+class CustomPasswordResetForm(PasswordResetForm):
+    def get_users(self, email):
+        """Given an email, return matching user(s) who should receive a reset.
+
+        Subclasses to allow password resets for users with unusable passwords.
+        """
+        email_field_name = User.get_email_field_name()
+        active_users = User._default_manager.filter(
+            **{
+                "%s__iexact" % email_field_name: email,
+                "is_active": True,
+            }
+        )
+        return (
+            u
+            for u in active_users
+            if _unicode_ci_compare(email, getattr(u, email_field_name))
+        )
+
+
 class CustomPasswordResetView(PasswordResetView):
     html_email_template_name = "registration/html_password_reset_email.html"
+    form_class = CustomPasswordResetForm
 
 
 class ActivateAccountView(View):

--- a/home/templates/email/unusable_password_notification/body.html
+++ b/home/templates/email/unusable_password_notification/body.html
@@ -1,0 +1,34 @@
+{% extends "email/base.html" %}
+
+{% block preheader %}Your Djangonaut Space account{% endblock preheader %}
+
+{% block before_cta %}
+  <p style="font-family: Helvetica, sans-serif; font-size: 16px; font-weight: normal; margin: 0; margin-bottom: 16px;">
+    As we transition from Google Forms and Sheets to our website, we created a Djangonaut
+    Space account for your email address to record your session participation.
+  </p>
+  <p style="font-family: Helvetica, sans-serif; font-size: 16px; font-weight: normal; margin: 0; margin-bottom: 16px;">
+    You do not currently have a password set for this account. Use the button below to set
+    one if you would like to access or manage your account.
+  </p>
+{% endblock before_cta %}
+
+{% block cta_button_text %}Set Password{% endblock cta_button_text %}
+
+{% block after_cta %}
+  <p style="font-family: Helvetica, sans-serif; font-size: 16px; font-weight: normal; margin: 0; margin-bottom: 16px;">
+    If you would prefer to have your account and all associated data removed, you can do so by:
+  </p>
+  <ol style="font-family: Helvetica, sans-serif; font-size: 16px; margin: 0; margin-bottom: 16px; padding-left: 20px;">
+    <li style="margin-bottom: 8px;">Setting a password using the button above.</li>
+    <li style="margin-bottom: 8px;">Logging in and visiting your profile.</li>
+    <li style="margin-bottom: 8px;">
+      Using the <a href="{{ delete_account_url }}" style="color: #5c0287;">"Delete Account"</a>
+      option to permanently remove your account and data.
+    </li>
+  </ol>
+  <p style="font-family: Helvetica, sans-serif; font-size: 16px; font-weight: normal; margin: 0; margin-bottom: 16px;">
+    If you have any questions, please contact us at
+    <a href="mailto:hello@djangonaut.space" style="color: #5c0287;">hello@djangonaut.space</a>.
+  </p>
+{% endblock after_cta %}

--- a/home/templates/email/unusable_password_notification/body.txt
+++ b/home/templates/email/unusable_password_notification/body.txt
@@ -1,0 +1,21 @@
+Hi {{ name }},
+
+As we transition from Google Forms and Sheets to our website, we created a Djangonaut Space account for your email address to record your session participation.
+
+You do not currently have a password set for this account. If you would like to access or manage your account, you can set a password using the link below:
+
+{{ cta_link }}
+
+If you would prefer to have your account and all associated data removed, you can do so by:
+
+1. Setting a password using the link above.
+2. Logging in and visiting your profile.
+3. Using the "Delete Account" option to permanently remove your account and data.
+
+Delete account page (requires login): {{ delete_account_url }}
+
+If you have any questions, please contact us at hello@djangonaut.space.
+
+Thank you,
+
+Djangonaut Space Organizers

--- a/home/templates/email/unusable_password_notification/subject.txt
+++ b/home/templates/email/unusable_password_notification/subject.txt
@@ -1,0 +1,1 @@
+A Djangonaut Space account has been created for you


### PR DESCRIPTION
We created users with unusuable passwords to record their session participation. These people should be notified of this so they can change their password and/or delete their accounts.