### PR TITLE
Auto-bump question ordering on conflict in survey admin

### DIFF
--- a/home/admin.py
+++ b/home/admin.py
@@ -648,6 +648,7 @@ class QuestionAdmin(DescriptiveSearchMixin, admin.ModelAdmin):
     readonly_fields = ("key",)
 
     def save_model(self, request, obj: Question, form, change: bool) -> None:
+        # Re-adjust the ordering on other questions of the survey.
         Question.bump_ordering(obj.survey_id, obj.ordering, exclude_pk=obj.pk)
         super().save_model(request, obj, form, change)
 

--- a/home/admin.py
+++ b/home/admin.py
@@ -647,11 +647,30 @@ class QuestionAdmin(DescriptiveSearchMixin, admin.ModelAdmin):
     )
     readonly_fields = ("key",)
 
+    def save_model(self, request, obj: Question, form, change: bool) -> None:
+        Question.bump_ordering(obj.survey_id, obj.ordering, exclude_pk=obj.pk)
+        super().save_model(request, obj, form, change)
+
 
 @admin.register(Survey)
 class SurveyAdmin(DescriptiveSearchMixin, admin.ModelAdmin):
     model = Survey
     inlines = [QuestionInline]
+
+    def save_formset(self, request, form, formset, change) -> None:
+        if formset.model is not Question:
+            return super().save_formset(request, form, formset, change)
+
+        instances = formset.save(commit=False)
+        for instance in instances:
+            Question.bump_ordering(
+                instance.survey_id, instance.ordering, exclude_pk=instance.pk
+            )
+            instance.save()
+        for obj in formset.deleted_objects:
+            obj.delete()
+        formset.save_m2m()
+
     fields = (
         "name",
         "description",

--- a/home/models/survey.py
+++ b/home/models/survey.py
@@ -1,6 +1,7 @@
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import models
+from django.db.models import F
 from django.urls import reverse
 from django.utils.safestring import mark_safe
 from django.utils.text import slugify
@@ -126,6 +127,22 @@ class Question(BaseModel):
                 fields=["survey", "key"], name="unique_question_key_per_survey"
             )
         ]
+
+    @classmethod
+    def bump_ordering(
+        cls, survey_id: int, ordering: int, exclude_pk: int | None = None
+    ) -> None:
+        """Shift questions in a survey at or above `ordering` up by one.
+
+        Only runs if another question already occupies `ordering`, making room for
+        a new or relocated question without requiring manual renumbering of the rest.
+        `exclude_pk` prevents a question from bumping itself when its position changes.
+        """
+        qs = cls.objects.filter(survey_id=survey_id, ordering__gte=ordering)
+        if exclude_pk is not None:
+            qs = qs.exclude(pk=exclude_pk)
+        if qs.filter(ordering=ordering).exists():
+            qs.update(ordering=F("ordering") + 1)
 
     def __str__(self):
         return f"{self.label}-survey-{self.survey.id}"

--- a/home/tests/test_survey_admin.py
+++ b/home/tests/test_survey_admin.py
@@ -11,7 +11,7 @@ from django.contrib.auth import get_user_model
 from django.urls import reverse
 from django.utils import timezone
 
-from home.admin import SurveyAdmin
+from home.admin import QuestionAdmin, SurveyAdmin
 from home.models import (
     Survey,
     Question,
@@ -366,3 +366,149 @@ class SurveyCSVImportViewTest(TestCase):
         # Check form is re-rendered with errors
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "Response ID")
+
+
+class _MockFormset:
+    """Minimal formset stub for testing save_formset without the admin machinery."""
+
+    model = Question
+
+    def __init__(self, instances, deleted_objects=None):
+        self._instances = instances
+        self.deleted_objects = deleted_objects or []
+
+    def save(self, commit=True):
+        return self._instances
+
+    def save_m2m(self):
+        pass
+
+
+class QuestionOrderingBumpTest(TestCase):
+    """Test that saving a question at a conflicting ordering bumps later questions."""
+
+    def setUp(self):
+        self.user = User.objects.create_superuser(
+            username="admin2", email="admin2@example.com", password="test"
+        )
+        self.survey = Survey.objects.create(name="Ordering Test Survey")
+        self.q1 = Question.objects.create(
+            survey=self.survey, label="Q1", ordering=1, type_field=TypeField.TEXT
+        )
+        self.q2 = Question.objects.create(
+            survey=self.survey, label="Q2", ordering=2, type_field=TypeField.TEXT
+        )
+        self.q3 = Question.objects.create(
+            survey=self.survey, label="Q3", ordering=3, type_field=TypeField.TEXT
+        )
+        self.factory = RequestFactory()
+
+    # --- QuestionAdmin.save_model ---
+
+    def test_save_model_bumps_question_at_same_ordering(self):
+        """A new question at ordering=2 bumps Q2 to 3 and Q3 to 4."""
+        admin = QuestionAdmin(Question, AdminSite())
+        new_q = Question(
+            survey=self.survey, label="New Q", ordering=2, type_field=TypeField.TEXT
+        )
+        request = self.factory.post("/admin/")
+        request.user = self.user
+
+        admin.save_model(request, new_q, form=None, change=False)
+
+        self.q2.refresh_from_db()
+        self.q3.refresh_from_db()
+        self.assertEqual(new_q.ordering, 2)
+        self.assertEqual(self.q2.ordering, 3)
+        self.assertEqual(self.q3.ordering, 4)
+
+    def test_save_model_no_conflict_leaves_others_unchanged(self):
+        """A new question at ordering=5 doesn't affect existing questions."""
+        admin = QuestionAdmin(Question, AdminSite())
+        new_q = Question(
+            survey=self.survey, label="New Q", ordering=5, type_field=TypeField.TEXT
+        )
+        request = self.factory.post("/admin/")
+        request.user = self.user
+
+        admin.save_model(request, new_q, form=None, change=False)
+
+        self.q1.refresh_from_db()
+        self.q2.refresh_from_db()
+        self.q3.refresh_from_db()
+        self.assertEqual(self.q1.ordering, 1)
+        self.assertEqual(self.q2.ordering, 2)
+        self.assertEqual(self.q3.ordering, 3)
+
+    def test_save_model_existing_question_move_bumps_others(self):
+        """Moving an existing question to a conflicting position bumps later questions."""
+        admin = QuestionAdmin(Question, AdminSite())
+        # Move Q1 from ordering=1 to ordering=2 (conflicts with Q2)
+        self.q1.ordering = 2
+        request = self.factory.post("/admin/")
+        request.user = self.user
+
+        admin.save_model(request, self.q1, form=None, change=True)
+
+        self.q2.refresh_from_db()
+        self.q3.refresh_from_db()
+        self.assertEqual(self.q1.ordering, 2)
+        self.assertEqual(self.q2.ordering, 3)
+        self.assertEqual(self.q3.ordering, 4)
+
+    def test_save_model_does_not_bump_questions_in_other_surveys(self):
+        """Bump only affects questions within the same survey."""
+        other_survey = Survey.objects.create(name="Other Survey")
+        other_q = Question.objects.create(
+            survey=other_survey, label="Other Q", ordering=2, type_field=TypeField.TEXT
+        )
+        admin = QuestionAdmin(Question, AdminSite())
+        new_q = Question(
+            survey=self.survey, label="New Q", ordering=2, type_field=TypeField.TEXT
+        )
+        request = self.factory.post("/admin/")
+        request.user = self.user
+
+        admin.save_model(request, new_q, form=None, change=False)
+
+        other_q.refresh_from_db()
+        self.assertEqual(other_q.ordering, 2)  # untouched
+
+    # --- SurveyAdmin.save_formset ---
+
+    def test_save_formset_bumps_on_inline_add(self):
+        """Adding a question via the inline bumps questions at the same position."""
+        survey_admin = SurveyAdmin(Survey, AdminSite())
+        new_q = Question(
+            survey=self.survey, label="Inline Q", ordering=2, type_field=TypeField.TEXT
+        )
+        formset = _MockFormset([new_q])
+        request = self.factory.post("/admin/")
+        request.user = self.user
+
+        survey_admin.save_formset(request, form=None, formset=formset, change=True)
+
+        self.q2.refresh_from_db()
+        self.q3.refresh_from_db()
+        self.assertEqual(new_q.ordering, 2)
+        self.assertEqual(self.q2.ordering, 3)
+        self.assertEqual(self.q3.ordering, 4)
+
+    def test_save_formset_no_conflict_no_bump(self):
+        """Inline add at a unique position leaves other questions unchanged."""
+        survey_admin = SurveyAdmin(Survey, AdminSite())
+        new_q = Question(
+            survey=self.survey, label="Inline Q", ordering=10, type_field=TypeField.TEXT
+        )
+        formset = _MockFormset([new_q])
+        request = self.factory.post("/admin/")
+        request.user = self.user
+
+        survey_admin.save_formset(request, form=None, formset=formset, change=True)
+
+        self.q1.refresh_from_db()
+        self.q2.refresh_from_db()
+        self.q3.refresh_from_db()
+        self.assertEqual(self.q1.ordering, 1)
+        self.assertEqual(self.q2.ordering, 2)
+        self.assertEqual(self.q3.ordering, 3)

--- a/home/tests/test_survey_admin.py
+++ b/home/tests/test_survey_admin.py
@@ -11,7 +11,9 @@ from django.contrib.auth import get_user_model
 from django.urls import reverse
 from django.utils import timezone
 
+from accounts.factories import UserFactory
 from home.admin import QuestionAdmin, SurveyAdmin
+from home.factories import QuestionFactory, SurveyFactory
 from home.models import (
     Survey,
     Question,
@@ -368,54 +370,32 @@ class SurveyCSVImportViewTest(TestCase):
         self.assertContains(response, "Response ID")
 
 
-class _MockFormset:
-    """Minimal formset stub for testing save_formset without the admin machinery."""
-
-    model = Question
-
-    def __init__(self, instances, deleted_objects=None):
-        self._instances = instances
-        self.deleted_objects = deleted_objects or []
-
-    def save(self, commit=True):
-        return self._instances
-
-    def save_m2m(self):
-        pass
-
-
 class QuestionOrderingBumpTest(TestCase):
     """Test that saving a question at a conflicting ordering bumps later questions."""
 
     def setUp(self):
-        self.user = User.objects.create_superuser(
-            username="admin2", email="admin2@example.com", password="test"
-        )
-        self.survey = Survey.objects.create(name="Ordering Test Survey")
-        self.q1 = Question.objects.create(
-            survey=self.survey, label="Q1", ordering=1, type_field=TypeField.TEXT
-        )
-        self.q2 = Question.objects.create(
-            survey=self.survey, label="Q2", ordering=2, type_field=TypeField.TEXT
-        )
-        self.q3 = Question.objects.create(
-            survey=self.survey, label="Q3", ordering=3, type_field=TypeField.TEXT
-        )
-        self.factory = RequestFactory()
+        self.user = UserFactory(is_superuser=True, is_staff=True)
+        self.survey = SurveyFactory()
+        self.q1 = QuestionFactory(survey=self.survey, ordering=1)
+        self.q2 = QuestionFactory(survey=self.survey, ordering=2)
+        self.q3 = QuestionFactory(survey=self.survey, ordering=3)
+        self.request_factory = RequestFactory()
+
+    def _make_request(self):
+        request = self.request_factory.post("/admin/")
+        request.user = self.user
+        return request
 
     # --- QuestionAdmin.save_model ---
 
     def test_save_model_bumps_question_at_same_ordering(self):
         """A new question at ordering=2 bumps Q2 to 3 and Q3 to 4."""
-        admin = QuestionAdmin(Question, AdminSite())
         new_q = Question(
             survey=self.survey, label="New Q", ordering=2, type_field=TypeField.TEXT
         )
-        request = self.factory.post("/admin/")
-        request.user = self.user
-
-        admin.save_model(request, new_q, form=None, change=False)
-
+        QuestionAdmin(Question, AdminSite()).save_model(
+            self._make_request(), new_q, form=None, change=False
+        )
         self.q2.refresh_from_db()
         self.q3.refresh_from_db()
         self.assertEqual(new_q.ordering, 2)
@@ -424,14 +404,12 @@ class QuestionOrderingBumpTest(TestCase):
 
     def test_save_model_no_conflict_leaves_others_unchanged(self):
         """A new question at ordering=5 doesn't affect existing questions."""
-        admin = QuestionAdmin(Question, AdminSite())
         new_q = Question(
             survey=self.survey, label="New Q", ordering=5, type_field=TypeField.TEXT
         )
-        request = self.factory.post("/admin/")
-        request.user = self.user
-
-        admin.save_model(request, new_q, form=None, change=False)
+        QuestionAdmin(Question, AdminSite()).save_model(
+            self._make_request(), new_q, form=None, change=False
+        )
 
         self.q1.refresh_from_db()
         self.q2.refresh_from_db()
@@ -442,14 +420,10 @@ class QuestionOrderingBumpTest(TestCase):
 
     def test_save_model_existing_question_move_bumps_others(self):
         """Moving an existing question to a conflicting position bumps later questions."""
-        admin = QuestionAdmin(Question, AdminSite())
-        # Move Q1 from ordering=1 to ordering=2 (conflicts with Q2)
         self.q1.ordering = 2
-        request = self.factory.post("/admin/")
-        request.user = self.user
-
-        admin.save_model(request, self.q1, form=None, change=True)
-
+        QuestionAdmin(Question, AdminSite()).save_model(
+            self._make_request(), self.q1, form=None, change=True
+        )
         self.q2.refresh_from_db()
         self.q3.refresh_from_db()
         self.assertEqual(self.q1.ordering, 2)
@@ -458,57 +432,55 @@ class QuestionOrderingBumpTest(TestCase):
 
     def test_save_model_does_not_bump_questions_in_other_surveys(self):
         """Bump only affects questions within the same survey."""
-        other_survey = Survey.objects.create(name="Other Survey")
-        other_q = Question.objects.create(
-            survey=other_survey, label="Other Q", ordering=2, type_field=TypeField.TEXT
-        )
-        admin = QuestionAdmin(Question, AdminSite())
+        other_q = QuestionFactory(survey=SurveyFactory(), ordering=2)
         new_q = Question(
             survey=self.survey, label="New Q", ordering=2, type_field=TypeField.TEXT
         )
-        request = self.factory.post("/admin/")
-        request.user = self.user
-
-        admin.save_model(request, new_q, form=None, change=False)
-
+        QuestionAdmin(Question, AdminSite()).save_model(
+            self._make_request(), new_q, form=None, change=False
+        )
         other_q.refresh_from_db()
-        self.assertEqual(other_q.ordering, 2)  # untouched
-
-    # --- SurveyAdmin.save_formset ---
+        self.assertEqual(other_q.ordering, 2)
 
     def test_save_formset_bumps_on_inline_add(self):
-        """Adding a question via the inline bumps questions at the same position."""
-        survey_admin = SurveyAdmin(Survey, AdminSite())
-        new_q = Question(
-            survey=self.survey, label="Inline Q", ordering=2, type_field=TypeField.TEXT
+        """Adding a question via the inline bumps the existing question at that position."""
+        self.client.force_login(self.user)
+        url = reverse("admin:home_survey_change", args=[self.survey.pk])
+        response = self.client.post(
+            url,
+            {
+                "name": self.survey.name,
+                "description": "A test survey",
+                "editable": "on",
+                "deletable": "on",
+                # The inline prefix is "questions" - Django derives it from the FK's related_name.
+                "questions-TOTAL_FORMS": "2",
+                "questions-INITIAL_FORMS": "1",
+                "questions-MIN_NUM_FORMS": "0",
+                "questions-MAX_NUM_FORMS": "1000",
+                # Existing question at ordering=2
+                "questions-0-id": str(self.q2.pk),
+                "questions-0-label": self.q2.label,
+                "questions-0-ordering": "2",
+                "questions-0-type_field": TypeField.TEXT,
+                "questions-0-required": "on",
+                "questions-0-sensitive": "",
+                "questions-0-choices": "",
+                "questions-0-help_text": "",
+                # New question also at ordering=2 — should bump q2 to 3
+                "questions-1-id": "",
+                "questions-1-label": "New Q",
+                "questions-1-ordering": "2",
+                "questions-1-type_field": TypeField.TEXT,
+                "questions-1-required": "on",
+                "questions-1-sensitive": "",
+                "questions-1-choices": "",
+                "questions-1-help_text": "",
+            },
         )
-        formset = _MockFormset([new_q])
-        request = self.factory.post("/admin/")
-        request.user = self.user
 
-        survey_admin.save_formset(request, form=None, formset=formset, change=True)
-
+        self.assertEqual(response.status_code, 302)
         self.q2.refresh_from_db()
-        self.q3.refresh_from_db()
+        new_q = Question.objects.get(label="New Q")
         self.assertEqual(new_q.ordering, 2)
         self.assertEqual(self.q2.ordering, 3)
-        self.assertEqual(self.q3.ordering, 4)
-
-    def test_save_formset_no_conflict_no_bump(self):
-        """Inline add at a unique position leaves other questions unchanged."""
-        survey_admin = SurveyAdmin(Survey, AdminSite())
-        new_q = Question(
-            survey=self.survey, label="Inline Q", ordering=10, type_field=TypeField.TEXT
-        )
-        formset = _MockFormset([new_q])
-        request = self.factory.post("/admin/")
-        request.user = self.user
-
-        survey_admin.save_formset(request, form=None, formset=formset, change=True)
-
-        self.q1.refresh_from_db()
-        self.q2.refresh_from_db()
-        self.q3.refresh_from_db()
-        self.assertEqual(self.q1.ordering, 1)
-        self.assertEqual(self.q2.ordering, 2)
-        self.assertEqual(self.q3.ordering, 3)


### PR DESCRIPTION
When a question is saved at a position already occupied in the same survey, all questions at that position and above shift up by one. This applies via both QuestionAdmin and the SurveyAdmin inline.

Closes #707