### PR TITLE
Ensure datetime fields in email templates use time_is_link filter

### DIFF
--- a/home/templates/email/acceptance_reminder/body.html
+++ b/home/templates/email/acceptance_reminder/body.html
@@ -9,7 +9,7 @@
   </p>
 
   <p style="font-family: Helvetica, sans-serif; font-size: 16px; font-weight: normal; margin: 0; margin-bottom: 16px;">
-    Please confirm your acceptance by <strong>{{ membership.acceptance_deadline|date:"l F jS" }}</strong> (<a href="{{ membership.acceptance_deadline|time_is_link:'1200' }}" style="color: #5c0287;">12:00 UTC</a>).
+    Please confirm your acceptance by <strong><a href="{{ membership.acceptance_deadline|time_is_link:'1200' }}" style="color: #5c0287;">{{ membership.acceptance_deadline|date:"l F jS" }}</a></strong> (12:00 UTC).
   </p>
 
   <p style="font-family: Helvetica, sans-serif; font-size: 16px; font-weight: normal; margin: 0; margin-bottom: 16px;">

--- a/home/templates/email/acceptance_reminder/body.html
+++ b/home/templates/email/acceptance_reminder/body.html
@@ -9,7 +9,7 @@
   </p>
 
   <p style="font-family: Helvetica, sans-serif; font-size: 16px; font-weight: normal; margin: 0; margin-bottom: 16px;">
-    Please confirm your acceptance by <strong><a href="{{ membership.acceptance_deadline|time_is_link:'1200' }}" style="color: #5c0287;">{{ membership.acceptance_deadline|date:"l F jS" }}</a></strong> (12:00 UTC).
+    Please confirm your acceptance by <strong>{{ membership.acceptance_deadline|date:"l F jS" }}</strong> (<a href="{{ membership.acceptance_deadline|time_is_link:'1200' }}" style="color: #5c0287;">12:00 UTC</a>).
   </p>
 
   <p style="font-family: Helvetica, sans-serif; font-size: 16px; font-weight: normal; margin: 0; margin-bottom: 16px;">

--- a/home/templates/email/acceptance_reminder/body.txt
+++ b/home/templates/email/acceptance_reminder/body.txt
@@ -2,7 +2,7 @@ Hello,
 
 We emailed you an invitation to join the Djangonaut Program and it's not too late to confirm your place as a Djangonaut! ⏰
 
-Please confirm your acceptance by visiting {{ acceptance_url }} and let us know whether you can be one of our Djangonauts by {{ membership.acceptance_deadline|date:"l F jS" }} (12:00 UTC).
+Please confirm your acceptance by visiting {{ acceptance_url }} and let us know whether you can be one of our Djangonauts by {{ membership.acceptance_deadline|date:"l F jS" }} ({{ membership.acceptance_deadline|time_is_link:"1200" }}).
 
 Otherwise, we may not be able to accommodate you this round.
 

--- a/home/templates/email/acceptance_reminder/body.txt
+++ b/home/templates/email/acceptance_reminder/body.txt
@@ -2,7 +2,7 @@ Hello,
 
 We emailed you an invitation to join the Djangonaut Program and it's not too late to confirm your place as a Djangonaut! ⏰
 
-Please confirm your acceptance by visiting {{ acceptance_url }} and let us know whether you can be one of our Djangonauts by {{ membership.acceptance_deadline|date:"l F jS" }} ({{ membership.acceptance_deadline|time_is_link:"1200" }}).
+Please confirm your acceptance by visiting {{ acceptance_url }} and let us know whether you can be one of our Djangonauts by {{ membership.acceptance_deadline|date:"l F jS" }} at 12:00pm UTC ({{ membership.acceptance_deadline|time_is_link:"1200" }}).
 
 Otherwise, we may not be able to accommodate you this round.
 

--- a/home/templates/email/event_rsvp/body.txt
+++ b/home/templates/email/event_rsvp/body.txt
@@ -2,7 +2,7 @@ Event RVSP Confirmation
 
 Hello {{ user.first_name }},
 
-This is a reminder that you successfully RSVPed for an event with Djangonaut Space on {{ event.start_time|date:"Y/m/d" }}.
+This is a reminder that you successfully RSVPed for an event with Djangonaut Space on {{ event.start_time|date:"Y/m/d" }} ({{ event.start_time|time_is_link }}).
 
 To see event details or to cancel your RSVP please visit the event page at {{ event.get_full_url  }}.
 

--- a/home/templates/email/event_rsvp_cancel/body.txt
+++ b/home/templates/email/event_rsvp_cancel/body.txt
@@ -2,7 +2,7 @@ Event RVSP Cancelation
 
 Hello {{ user.first_name }},
 
-This is a reminder that you successfully canceled your RSVP for an event with Djangonaut Space on {{ event.start_time|date:"Y/m/d" }}.
+This is a reminder that you successfully canceled your RSVP for an event with Djangonaut Space on {{ event.start_time|date:"Y/m/d" }} ({{ event.start_time|time_is_link }}).
 
 To see event details or to change your RSVP please visit the event page at {{ event.get_full_url  }}.
 

--- a/home/templates/email/session_accepted/body.html
+++ b/home/templates/email/session_accepted/body.html
@@ -13,7 +13,7 @@
   </p>
 
   <p style="font-family: Helvetica, sans-serif; font-size: 16px; font-weight: normal; margin: 0; margin-bottom: 16px;">
-    We hope you are as excited as we are and can commit to join this program! Please confirm your acceptance by <strong>{{ membership.acceptance_deadline|date:"F d, Y" }}</strong> (<a href="{{ membership.acceptance_deadline|time_is_link:'1200' }}" style="color: #5c0287;">12:00 UTC</a>).
+    We hope you are as excited as we are and can commit to join this program! Please confirm your acceptance by <strong><a href="{{ membership.acceptance_deadline|time_is_link:'1200' }}" style="color: #5c0287;">{{ membership.acceptance_deadline|date:"F d, Y" }}</a></strong> (12:00 UTC).
   </p>
 {% endblock before_cta %}
 
@@ -50,7 +50,7 @@
   </p>
 
     <p style="font-family: Helvetica, sans-serif; font-size: 16px; font-weight: normal; margin: 0; margin-bottom: 16px;">
-    Is this no longer a good time for you? Please let us know before <i>{{ membership.acceptance_deadline|date:"F d, Y" }}</i> (<a href="{{ membership.acceptance_deadline|time_is_link:'1200' }}" style="color: #5c0287;">12:00 UTC</a>)
+    Is this no longer a good time for you? Please let us know before <i><a href="{{ membership.acceptance_deadline|time_is_link:'1200' }}" style="color: #5c0287;">{{ membership.acceptance_deadline|date:"F d, Y" }}</a></i> (12:00 UTC)
 
     </p>
 

--- a/home/templates/email/session_accepted/body.txt
+++ b/home/templates/email/session_accepted/body.txt
@@ -5,7 +5,7 @@ Congratulations! You've been selected to join the Djangonaut Program! 🎊 You w
 We are excited by your desire to help contribute back to Django and we want to rocket launch your success! 🚀
 
 We hope you are as excited as we are and can commit to join this program!
-Please confirm your acceptance by visiting {{ acceptance_url }} and let us know whether you can be one of our Djangonauts by {{ membership.acceptance_deadline|date:"F d, Y" }} ({{ membership.acceptance_deadline|time_is_link:"1200" }}).
+Please confirm your acceptance by visiting {{ acceptance_url }} and let us know whether you can be one of our Djangonauts by {{ membership.acceptance_deadline|date:"F d, Y" }} at 12:00pm UTC ({{ membership.acceptance_deadline|time_is_link:"1200" }}).
 
 The Djangonaut Program aims to level up the Django code contributions from our community and to help you become a future leader of Django. 💪 This is an 8 week group mentoring program with an emphasis on sustainability and longevity.
 
@@ -22,7 +22,7 @@ As a rough guide, we expect the time commitment of a Djangonaut to be around 4 h
 
 To learn more about the program you can read our documentation here: https://github.com/djangonaut-space/program
 
-Is this no longer a good time for you? Please let us know before {{ membership.acceptance_deadline|date:"F d, Y" }} ({{ membership.acceptance_deadline|time_is_link:"1200" }}).
+Is this no longer a good time for you? Please let us know before {{ membership.acceptance_deadline|date:"F d, Y" }} at 12:00pm UTC ({{ membership.acceptance_deadline|time_is_link:"1200" }}).
 
 
 Let us know if you're not available by visiting {{ acceptance_url }}

--- a/home/templates/email/session_accepted/body.txt
+++ b/home/templates/email/session_accepted/body.txt
@@ -5,7 +5,7 @@ Congratulations! You've been selected to join the Djangonaut Program! 🎊 You w
 We are excited by your desire to help contribute back to Django and we want to rocket launch your success! 🚀
 
 We hope you are as excited as we are and can commit to join this program!
-Please confirm your acceptance by visiting {{ acceptance_url }} and let us know whether you can be one of our Djangonauts by {{ membership.acceptance_deadline|date:"F d, Y" }} (12:00 UTC).
+Please confirm your acceptance by visiting {{ acceptance_url }} and let us know whether you can be one of our Djangonauts by {{ membership.acceptance_deadline|date:"F d, Y" }} ({{ membership.acceptance_deadline|time_is_link:"1200" }}).
 
 The Djangonaut Program aims to level up the Django code contributions from our community and to help you become a future leader of Django. 💪 This is an 8 week group mentoring program with an emphasis on sustainability and longevity.
 
@@ -22,7 +22,8 @@ As a rough guide, we expect the time commitment of a Djangonaut to be around 4 h
 
 To learn more about the program you can read our documentation here: https://github.com/djangonaut-space/program
 
-Is this no longer a good time for you? Please let us know before {{ membership.acceptance_deadline|date:"F d, Y" }} (12:00 UTC).
+Is this no longer a good time for you? Please let us know before {{ membership.acceptance_deadline|date:"F d, Y" }} ({{ membership.acceptance_deadline|time_is_link:"1200" }}).
+
 
 Let us know if you're not available by visiting {{ acceptance_url }}
 


### PR DESCRIPTION
As methioned in issue #720 this pr makes sure all the templates use the time_is_link template tags in the email templates. Closes #720 