### PR TITLE
Add support for syncing users to Buttondown.

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -33,8 +33,5 @@
       "Bash(uv run python manage.py flush:*)",
       "Bash(uv run python manage.py dbshell:*)"
     ]
-  },
-  "env": {
-    "DJANGO_SETTINGS_MODULE": "indymeet.settings.dev"
   }
 }

--- a/accounts/admin.py
+++ b/accounts/admin.py
@@ -13,7 +13,13 @@ from django.db.models import Exists, OuterRef, QuerySet
 from django.http import HttpResponse, HttpResponseRedirect
 from django.urls import reverse
 
-from accounts.models import CustomUser, Link, UserAvailability, UserProfile
+from accounts.models import (
+    ButtondownAccount,
+    CustomUser,
+    Link,
+    UserAvailability,
+    UserProfile,
+)
 from home.models.session import SessionMembership
 from indymeet.admin import DescriptiveSearchMixin
 
@@ -152,6 +158,14 @@ class UserProfileAdmin(ExportCsvMixin, DescriptiveSearchMixin, admin.ModelAdmin)
     inlines = (LinksInline,)
     model = UserProfile
     actions = ["export_as_csv"]
+    list_filter = (RelatedUserPastDjangonautFilter, RelatedUserPastSessionMemberFilter)
+
+
+@admin.register(ButtondownAccount)
+class ButtondownAccountAdmin(DescriptiveSearchMixin, admin.ModelAdmin):
+    model = ButtondownAccount
+    search_fields = ["buttondown_identifier", "user__email"]
+    list_display = ["user", "buttondown_identifier"]
     list_filter = (RelatedUserPastDjangonautFilter, RelatedUserPastSessionMemberFilter)
 
 

--- a/accounts/management/commands/sync_buttondown.py
+++ b/accounts/management/commands/sync_buttondown.py
@@ -27,7 +27,9 @@ class Command(BaseCommand):
         dry_run = options["dry_run"]
         count = 0
 
-        for user in User.objects.filter(is_active=True).iterator():
+        for user in User.objects.filter(
+            is_active=True, profile__email_confirmed=True
+        ).iterator():
             if dry_run:
                 self.stdout.write(f"Would sync: {user.email} (pk={user.pk})")
             else:

--- a/accounts/management/commands/sync_buttondown.py
+++ b/accounts/management/commands/sync_buttondown.py
@@ -1,0 +1,46 @@
+from django.contrib.auth import get_user_model
+from django.core.management.base import BaseCommand
+
+from home.integrations.buttondown.service import buttondown_enabled
+from home.tasks.sync_buttondown import sync_user_to_buttondown
+
+User = get_user_model()
+
+
+class Command(BaseCommand):
+    help = "Enqueue a Buttondown sync task for every active user."
+
+    def add_arguments(self, parser) -> None:
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="List users that would be synced without enqueueing tasks.",
+        )
+
+    def handle(self, *args, **options) -> None:
+        if not buttondown_enabled():
+            self.stderr.write(
+                self.style.ERROR("BUTTONDOWN_API_KEY is not set; aborting.")
+            )
+            return
+
+        dry_run = options["dry_run"]
+        count = 0
+
+        for user in User.objects.filter(is_active=True).iterator():
+            if dry_run:
+                self.stdout.write(f"Would sync: {user.email} (pk={user.pk})")
+            else:
+                sync_user_to_buttondown.enqueue(user.pk)
+            count += 1
+
+        if dry_run:
+            self.stdout.write(
+                self.style.WARNING(
+                    f"Dry run complete: {count} user(s) would be synced."
+                )
+            )
+        else:
+            self.stdout.write(
+                self.style.SUCCESS(f"Enqueued Buttondown sync for {count} user(s).")
+            )

--- a/accounts/migrations/0017_buttondownaccount.py
+++ b/accounts/migrations/0017_buttondownaccount.py
@@ -1,0 +1,44 @@
+from django.conf import settings
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("accounts", "0016_userprofile_interested_in_validator"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="ButtondownAccount",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                (
+                    "user",
+                    models.OneToOneField(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="buttondown_account",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+                ("buttondown_identifier", models.CharField(max_length=255)),
+                ("last_updated", models.DateTimeField(auto_now=True)),
+            ],
+        ),
+        migrations.AddConstraint(
+            model_name="buttondownaccount",
+            constraint=models.UniqueConstraint(
+                fields=["buttondown_identifier"],
+                name="unique_buttondown_identifier",
+            ),
+        ),
+    ]

--- a/accounts/models.py
+++ b/accounts/models.py
@@ -292,6 +292,29 @@ class UserAvailability(models.Model):
         return settings.BASE_URL + self.get_absolute_url()
 
 
+class ButtondownAccount(models.Model):
+    """Tracks a user's Buttondown subscriber record for newsletter sync."""
+
+    user = models.OneToOneField(
+        "CustomUser",
+        on_delete=models.CASCADE,
+        related_name="buttondown_account",
+    )
+    buttondown_identifier = models.CharField(max_length=255)
+    last_updated = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        constraints = [
+            models.UniqueConstraint(
+                fields=["buttondown_identifier"],
+                name="unique_buttondown_identifier",
+            )
+        ]
+
+    def __str__(self) -> str:
+        return f"ButtondownAccount({self.user_id}, {self.buttondown_identifier})"
+
+
 # ====================== Signals =======================
 @receiver(post_save, sender=CustomUser)
 def create_profile(sender, instance, created, **kwargs):

--- a/accounts/receivers.py
+++ b/accounts/receivers.py
@@ -53,10 +53,9 @@ def sync_buttondown_on_profile_save(
     """
     Enqueue a Buttondown sync when a UserProfile is saved.
 
-    Triggers on new signups (created=True) to add the user to Buttondown,
-    and on subsequent saves for users already synced (has ButtondownAccount)
-    to keep tags and subscription status up to date.
+    Fires on every save where email_confirmed is True, keeping tags and
+    subscription status in sync with any profile changes.
     """
-    if not buttondown_enabled() or raw:
+    if not buttondown_enabled() or raw or not instance.email_confirmed:
         return
-    sync_user_to_buttondown.enqueue(instance.user.pk)
+    sync_user_to_buttondown.enqueue(instance.user_id)

--- a/accounts/receivers.py
+++ b/accounts/receivers.py
@@ -1,5 +1,6 @@
 """
-Signal handlers for managing user groups and staff status based on SessionMembership.
+Signal handlers for managing user groups and staff status based on SessionMembership,
+and for syncing users to the Buttondown newsletter.
 """
 
 from home import constants
@@ -7,6 +8,9 @@ from django.contrib.auth.models import Group
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 
+from accounts.models import UserProfile
+from home.integrations.buttondown.service import buttondown_enabled
+from home.tasks.sync_buttondown import sync_user_to_buttondown
 from home.models.session import SessionMembership
 
 
@@ -36,3 +40,23 @@ def manage_organizer_group_on_save(
 
         group, _ = Group.objects.get_or_create(name="Session Organizers")
         user.groups.add(group)
+
+
+@receiver(
+    post_save,
+    sender=UserProfile,
+    dispatch_uid="accounts.sync_buttondown_on_profile_save",
+)
+def sync_buttondown_on_profile_save(
+    sender, instance: UserProfile, created: bool, **kwargs
+) -> None:
+    """
+    Enqueue a Buttondown sync when a UserProfile is saved.
+
+    Triggers on new signups (created=True) to add the user to Buttondown,
+    and on subsequent saves for users already synced (has ButtondownAccount)
+    to keep tags and subscription status up to date.
+    """
+    if not buttondown_enabled():
+        return
+    sync_user_to_buttondown.enqueue(instance.user.pk)

--- a/accounts/receivers.py
+++ b/accounts/receivers.py
@@ -48,7 +48,7 @@ def manage_organizer_group_on_save(
     dispatch_uid="accounts.sync_buttondown_on_profile_save",
 )
 def sync_buttondown_on_profile_save(
-    sender, instance: UserProfile, created: bool, **kwargs
+    sender, instance: UserProfile, created: bool, raw: bool, **kwargs
 ) -> None:
     """
     Enqueue a Buttondown sync when a UserProfile is saved.
@@ -57,6 +57,6 @@ def sync_buttondown_on_profile_save(
     and on subsequent saves for users already synced (has ButtondownAccount)
     to keep tags and subscription status up to date.
     """
-    if not buttondown_enabled():
+    if not buttondown_enabled() or raw:
         return
     sync_user_to_buttondown.enqueue(instance.user.pk)

--- a/accounts/tasks.py
+++ b/accounts/tasks.py
@@ -29,12 +29,7 @@ def delete_user_account(user_id: int) -> None:
         user_email = user.email
         user_name = user.get_full_name() or user.username
         if buttondown_enabled():
-            try:
-                buttondown_service.remove_user_for_user(user)
-            except Exception:
-                logger.exception(
-                    "Failed to remove Buttondown subscriber for user %s", user.pk
-                )
+            buttondown_service.remove_user_for_user(user)
         user.delete()
         email.send(
             email_template="account_deleted_confirmation",

--- a/accounts/tasks.py
+++ b/accounts/tasks.py
@@ -1,9 +1,14 @@
 """Background task for permanent user account deletion."""
 
+import logging
+
 from django.contrib.auth import get_user_model
 from django_tasks import task
 
 from home import email
+from home.integrations.buttondown.service import buttondown_enabled, buttondown_service
+
+logger = logging.getLogger(__name__)
 
 User = get_user_model()
 
@@ -20,8 +25,16 @@ def delete_user_account(user_id: int) -> None:
     except User.DoesNotExist:
         pass
     else:
+
         user_email = user.email
         user_name = user.get_full_name() or user.username
+        if buttondown_enabled():
+            try:
+                buttondown_service.remove_user_for_user(user)
+            except Exception:
+                logger.exception(
+                    "Failed to remove Buttondown subscriber for user %s", user.pk
+                )
         user.delete()
         email.send(
             email_template="account_deleted_confirmation",

--- a/accounts/tasks.py
+++ b/accounts/tasks.py
@@ -25,7 +25,6 @@ def delete_user_account(user_id: int) -> None:
     except User.DoesNotExist:
         pass
     else:
-
         user_email = user.email
         user_name = user.get_full_name() or user.username
         if buttondown_enabled():

--- a/accounts/tests/test_buttondown_command.py
+++ b/accounts/tests/test_buttondown_command.py
@@ -1,0 +1,83 @@
+"""Tests for the sync_buttondown management command."""
+
+import json
+from io import StringIO
+
+import responses as rsps
+from django.core.management import call_command
+from django.test import TestCase, override_settings
+
+from accounts.factories import UserFactory
+from accounts.models import UserProfile
+
+BD_SETTINGS = {"BUTTONDOWN_API_KEY": "test-api-key"}
+_BASE_URL = "https://api.buttondown.email/v1"
+
+
+class SyncButtondownCommandTests(TestCase):
+    """
+    Management command tests use ImmediateBackend, so enqueued tasks run
+    synchronously. responses intercepts at the HTTP layer to verify the correct
+    users are synced without making real API calls.
+
+    Profile email_confirmed flags are set via queryset .update() to bypass
+    signals during test setup — only the command run itself triggers HTTP calls.
+    """
+
+    @override_settings(**BD_SETTINGS)
+    @rsps.activate
+    def test_syncs_active_confirmed_users(self):
+        active1 = UserFactory.create(is_active=True)
+        UserProfile.objects.filter(pk=active1.profile.pk).update(email_confirmed=True)
+        active2 = UserFactory.create(is_active=True)
+        UserProfile.objects.filter(pk=active2.profile.pk).update(email_confirmed=True)
+        UserFactory.create(is_active=False)
+
+        _ids = iter(["uuid-cmd-1", "uuid-cmd-2"])
+
+        def _create_subscriber(request):
+            return (201, {}, json.dumps({"id": next(_ids)}))
+
+        rsps.add(rsps.GET, f"{_BASE_URL}/subscribers", json={"results": []})
+        rsps.add_callback(
+            rsps.POST, f"{_BASE_URL}/subscribers", callback=_create_subscriber
+        )
+
+        call_command("sync_buttondown", stdout=StringIO(), stderr=StringIO())
+
+        get_calls = [c for c in rsps.calls if c.request.method == "GET"]
+        self.assertEqual(len(get_calls), 2)
+
+    @override_settings(**BD_SETTINGS)
+    @rsps.activate
+    def test_skips_users_with_unconfirmed_email(self):
+        user = UserFactory.create(is_active=True)
+        UserProfile.objects.filter(pk=user.profile.pk).update(email_confirmed=False)
+
+        call_command("sync_buttondown", stdout=StringIO(), stderr=StringIO())
+
+        self.assertEqual(len(rsps.calls), 0)
+
+    @override_settings(**BD_SETTINGS)
+    @rsps.activate
+    def test_dry_run_does_not_sync(self):
+        user = UserFactory.create(is_active=True)
+        UserProfile.objects.filter(pk=user.profile.pk).update(email_confirmed=True)
+
+        out = StringIO()
+        call_command("sync_buttondown", dry_run=True, stdout=out, stderr=StringIO())
+
+        self.assertEqual(len(rsps.calls), 0)
+        self.assertIn("Dry run", out.getvalue())
+
+    @override_settings(BUTTONDOWN_API_KEY="")
+    @rsps.activate
+    def test_aborts_when_not_configured(self):
+        user = UserFactory.create(is_active=True)
+        UserProfile.objects.filter(pk=user.profile.pk).update(email_confirmed=True)
+
+        err = StringIO()
+        call_command("sync_buttondown", stdout=StringIO(), stderr=err)
+
+        self.assertEqual(len(rsps.calls), 0)
+        self.assertIn("BUTTONDOWN_API_KEY", err.getvalue())

--- a/accounts/tests/test_buttondown_signals.py
+++ b/accounts/tests/test_buttondown_signals.py
@@ -33,6 +33,7 @@ class ButtondownSignalTests(TestCase):
             json={"id": "bd-uuid-signal"},
         )
 
+        user.profile.email_confirmed = True
         user.profile.bio = "updated"
         user.profile.save()
 
@@ -43,7 +44,7 @@ class ButtondownSignalTests(TestCase):
     @rsps.activate
     def test_profile_save_always_triggers_sync_when_configured(self):
         user = UserFactory.create()
-        rsps.add(rsps.GET, f"{_BASE_URL}/subscribers", json={"results": []})
+        rsps.add(rsps.GET, f"{_BASE_URL}/subscribers/{user.email}", status=404)
         rsps.add(
             rsps.POST,
             f"{_BASE_URL}/subscribers",
@@ -51,6 +52,7 @@ class ButtondownSignalTests(TestCase):
             status=201,
         )
 
+        user.profile.email_confirmed = True
         user.profile.bio = "updated"
         user.profile.save()
 
@@ -60,7 +62,7 @@ class ButtondownSignalTests(TestCase):
     @rsps.activate
     def test_profile_save_triggers_sync_when_opting_in_with_no_account(self):
         user = UserFactory.create()
-        rsps.add(rsps.GET, f"{_BASE_URL}/subscribers", json={"results": []})
+        rsps.add(rsps.GET, f"{_BASE_URL}/subscribers/{user.email}", status=404)
         rsps.add(
             rsps.POST,
             f"{_BASE_URL}/subscribers",
@@ -68,6 +70,7 @@ class ButtondownSignalTests(TestCase):
             status=201,
         )
 
+        user.profile.email_confirmed = True
         user.profile.receiving_newsletter = True
         user.profile.save()
 
@@ -75,18 +78,23 @@ class ButtondownSignalTests(TestCase):
 
     @override_settings(**BD_SETTINGS)
     @rsps.activate
-    def test_new_signup_triggers_sync(self):
-        rsps.add(rsps.GET, f"{_BASE_URL}/subscribers", json={"results": []})
-        rsps.add(
-            rsps.POST,
-            f"{_BASE_URL}/subscribers",
-            json={"id": "new-uuid"},
-            status=201,
-        )
-
+    def test_new_signup_does_not_trigger_sync_when_email_not_confirmed(self):
         User.objects.create_user(username="newuser", email="new@example.com")
 
-        self.assertGreaterEqual(len(rsps.calls), 1)
+        self.assertEqual(len(rsps.calls), 0)
+
+    @override_settings(**BD_SETTINGS)
+    @rsps.activate
+    def test_profile_save_does_not_sync_when_email_not_confirmed(self):
+        user = UserFactory.create()
+        ButtondownAccount.objects.create(
+            user=user, buttondown_identifier="bd-uuid-signal"
+        )
+
+        user.profile.bio = "updated"
+        user.profile.save()
+
+        self.assertEqual(len(rsps.calls), 0)
 
     @override_settings(BUTTONDOWN_API_KEY="")
     @rsps.activate

--- a/accounts/tests/test_buttondown_signals.py
+++ b/accounts/tests/test_buttondown_signals.py
@@ -1,0 +1,112 @@
+"""Tests for the Buttondown signal handler in accounts/receivers.py."""
+
+import responses as rsps
+from django.contrib.auth import get_user_model
+from django.test import TestCase, override_settings
+
+from accounts.factories import UserFactory
+from accounts.models import ButtondownAccount
+
+BD_SETTINGS = {"BUTTONDOWN_API_KEY": "test-api-key"}
+_BASE_URL = "https://api.buttondown.email/v1"
+
+User = get_user_model()
+
+
+class ButtondownSignalTests(TestCase):
+    """
+    Signal tests verify the full signal→task→service→HTTP chain.
+    responses intercepts at the HTTP layer; tasks run synchronously via
+    ImmediateBackend configured in test settings.
+    """
+
+    @override_settings(**BD_SETTINGS)
+    @rsps.activate
+    def test_profile_save_triggers_sync_when_account_exists(self):
+        user = UserFactory.create()
+        ButtondownAccount.objects.create(
+            user=user, buttondown_identifier="bd-uuid-signal"
+        )
+        rsps.add(
+            rsps.PATCH,
+            f"{_BASE_URL}/subscribers/bd-uuid-signal",
+            json={"id": "bd-uuid-signal"},
+        )
+
+        user.profile.bio = "updated"
+        user.profile.save()
+
+        self.assertEqual(len(rsps.calls), 1)
+        self.assertEqual(rsps.calls[0].request.method, "PATCH")
+
+    @override_settings(**BD_SETTINGS)
+    @rsps.activate
+    def test_profile_save_always_triggers_sync_when_configured(self):
+        user = UserFactory.create()
+        rsps.add(rsps.GET, f"{_BASE_URL}/subscribers", json={"results": []})
+        rsps.add(
+            rsps.POST,
+            f"{_BASE_URL}/subscribers",
+            json={"id": "new-uuid"},
+            status=201,
+        )
+
+        user.profile.bio = "updated"
+        user.profile.save()
+
+        self.assertGreaterEqual(len(rsps.calls), 1)
+
+    @override_settings(**BD_SETTINGS)
+    @rsps.activate
+    def test_profile_save_triggers_sync_when_opting_in_with_no_account(self):
+        user = UserFactory.create()
+        rsps.add(rsps.GET, f"{_BASE_URL}/subscribers", json={"results": []})
+        rsps.add(
+            rsps.POST,
+            f"{_BASE_URL}/subscribers",
+            json={"id": "new-uuid"},
+            status=201,
+        )
+
+        user.profile.receiving_newsletter = True
+        user.profile.save()
+
+        self.assertGreaterEqual(len(rsps.calls), 1)
+
+    @override_settings(**BD_SETTINGS)
+    @rsps.activate
+    def test_new_signup_triggers_sync(self):
+        rsps.add(rsps.GET, f"{_BASE_URL}/subscribers", json={"results": []})
+        rsps.add(
+            rsps.POST,
+            f"{_BASE_URL}/subscribers",
+            json={"id": "new-uuid"},
+            status=201,
+        )
+
+        User.objects.create_user(username="newuser", email="new@example.com")
+
+        self.assertGreaterEqual(len(rsps.calls), 1)
+
+    @override_settings(BUTTONDOWN_API_KEY="")
+    @rsps.activate
+    def test_profile_save_does_not_sync_when_not_configured(self):
+        user = UserFactory.create()
+        ButtondownAccount.objects.create(
+            user=user, buttondown_identifier="bd-uuid-signal"
+        )
+
+        user.profile.bio = "updated"
+        user.profile.save()
+
+        self.assertEqual(len(rsps.calls), 0)
+
+    @override_settings(**BD_SETTINGS)
+    @rsps.activate
+    def test_raw_save_does_not_trigger_sync(self):
+        user = UserFactory.create()
+
+        user.profile.bio = "updated"
+        user.profile.save_base(raw=True)
+
+        self.assertEqual(len(rsps.calls), 0)

--- a/accounts/tests/test_delete_account_task.py
+++ b/accounts/tests/test_delete_account_task.py
@@ -1,16 +1,18 @@
 """Tests for account deletion background task."""
 
-from home import constants
 from unittest.mock import patch
 
+import responses as rsps
 from django.test import TestCase, override_settings
 
 from accounts.factories import UserFactory
-from accounts.models import ButtondownAccount, CustomUser, UserProfile
+from accounts.models import ButtondownAccount, CustomUser
 from accounts.tasks import delete_user_account
+from home import constants
 from home.factories import SessionFactory, SessionMembershipFactory
-from home.integrations.buttondown.service import buttondown_service
-from home.models import SessionMembership, Waitlist
+from home.models import Waitlist
+
+_BD_BASE_URL = "https://api.buttondown.email/v1"
 
 
 class DeleteUserAccountTaskTests(TestCase):
@@ -63,21 +65,23 @@ class DeleteUserAccountButtondownTests(TestCase):
 
     @patch("accounts.tasks.email.send")
     @override_settings(BUTTONDOWN_API_KEY="test-key")
+    @rsps.activate
     def test_removes_buttondown_subscriber_before_deletion(self, mock_send):
         user = UserFactory.create()
         ButtondownAccount.objects.create(
             user=user, buttondown_identifier="bd-uuid-task"
         )
         user_id = user.pk
+        rsps.add(rsps.DELETE, f"{_BD_BASE_URL}/subscribers/bd-uuid-task", status=204)
 
-        with patch.object(buttondown_service, "remove_user_for_user") as mock_remove:
-            delete_user_account.call(user_id=user_id)
+        delete_user_account.call(user_id=user_id)
 
-        mock_remove.assert_called_once()
+        self.assertEqual(len(rsps.calls), 1)
         self.assertFalse(CustomUser.objects.filter(pk=user_id).exists())
 
     @patch("accounts.tasks.email.send")
     @override_settings(BUTTONDOWN_API_KEY="")
+    @rsps.activate
     def test_skips_buttondown_when_not_configured(self, mock_send):
         user = UserFactory.create()
         ButtondownAccount.objects.create(
@@ -85,26 +89,23 @@ class DeleteUserAccountButtondownTests(TestCase):
         )
         user_id = user.pk
 
-        with patch.object(buttondown_service, "remove_user_for_user") as mock_remove:
-            delete_user_account.call(user_id=user_id)
+        delete_user_account.call(user_id=user_id)
 
-        mock_remove.assert_not_called()
+        self.assertEqual(len(rsps.calls), 0)
         self.assertFalse(CustomUser.objects.filter(pk=user_id).exists())
 
     @patch("accounts.tasks.email.send")
     @override_settings(BUTTONDOWN_API_KEY="test-key")
+    @rsps.activate
     def test_deletion_proceeds_when_buttondown_raises(self, mock_send):
         user = UserFactory.create()
         ButtondownAccount.objects.create(
             user=user, buttondown_identifier="bd-uuid-task"
         )
         user_id = user.pk
+        # 404 avoids the client's retry logic (500 would trigger 3 retries).
+        rsps.add(rsps.DELETE, f"{_BD_BASE_URL}/subscribers/bd-uuid-task", status=404)
 
-        with patch.object(
-            buttondown_service,
-            "remove_user_for_user",
-            side_effect=Exception("API down"),
-        ):
-            delete_user_account.call(user_id=user_id)  # should not raise
+        delete_user_account.call(user_id=user_id)  # should not raise
 
         self.assertFalse(CustomUser.objects.filter(pk=user_id).exists())

--- a/accounts/tests/test_delete_account_task.py
+++ b/accounts/tests/test_delete_account_task.py
@@ -6,9 +6,10 @@ from unittest.mock import patch
 from django.test import TestCase, override_settings
 
 from accounts.factories import UserFactory
-from accounts.models import CustomUser, UserProfile
+from accounts.models import ButtondownAccount, CustomUser, UserProfile
 from accounts.tasks import delete_user_account
 from home.factories import SessionFactory, SessionMembershipFactory
+from home.integrations.buttondown.service import buttondown_service
 from home.models import SessionMembership, Waitlist
 
 
@@ -55,3 +56,55 @@ class DeleteUserAccountTaskTests(TestCase):
             delete_user_account.call(user_id=self.user_id)
 
         self.assertFalse(CustomUser.objects.filter(pk=self.user_id).exists())
+
+
+class DeleteUserAccountButtondownTests(TestCase):
+    """Tests for Buttondown removal within delete_user_account."""
+
+    @patch("accounts.tasks.email.send")
+    @override_settings(BUTTONDOWN_API_KEY="test-key")
+    def test_removes_buttondown_subscriber_before_deletion(self, mock_send):
+        user = UserFactory.create()
+        ButtondownAccount.objects.create(
+            user=user, buttondown_identifier="bd-uuid-task"
+        )
+        user_id = user.pk
+
+        with patch.object(buttondown_service, "remove_user_for_user") as mock_remove:
+            delete_user_account.call(user_id=user_id)
+
+        mock_remove.assert_called_once()
+        self.assertFalse(CustomUser.objects.filter(pk=user_id).exists())
+
+    @patch("accounts.tasks.email.send")
+    @override_settings(BUTTONDOWN_API_KEY="")
+    def test_skips_buttondown_when_not_configured(self, mock_send):
+        user = UserFactory.create()
+        ButtondownAccount.objects.create(
+            user=user, buttondown_identifier="bd-uuid-task"
+        )
+        user_id = user.pk
+
+        with patch.object(buttondown_service, "remove_user_for_user") as mock_remove:
+            delete_user_account.call(user_id=user_id)
+
+        mock_remove.assert_not_called()
+        self.assertFalse(CustomUser.objects.filter(pk=user_id).exists())
+
+    @patch("accounts.tasks.email.send")
+    @override_settings(BUTTONDOWN_API_KEY="test-key")
+    def test_deletion_proceeds_when_buttondown_raises(self, mock_send):
+        user = UserFactory.create()
+        ButtondownAccount.objects.create(
+            user=user, buttondown_identifier="bd-uuid-task"
+        )
+        user_id = user.pk
+
+        with patch.object(
+            buttondown_service,
+            "remove_user_for_user",
+            side_effect=Exception("API down"),
+        ):
+            delete_user_account.call(user_id=user_id)  # should not raise
+
+        self.assertFalse(CustomUser.objects.filter(pk=user_id).exists())

--- a/docs/integrations/buttondown.md
+++ b/docs/integrations/buttondown.md
@@ -1,0 +1,50 @@
+# Buttondown Integration
+
+## Overview
+
+The platform integrates with [Buttondown](https://buttondown.com) to sync site users to a newsletter subscriber list. Tags reflect each user's roles, session history, and interests for list segmentation.
+
+## App Credentials
+
+The Buttondown account can be managed at: https://buttondown.com/settings
+
+## Required Credentials
+
+### API Key
+
+Retrieve the API key from **Settings → API** in the Buttondown dashboard.
+
+| Variable | Description |
+|---|---|
+| `BUTTONDOWN_API_KEY` | API key from the Buttondown settings page |
+
+Set this in the `.env` file locally or as an environment variable in production. If unset or empty the integration is disabled.
+
+### Webhook Secret
+
+The platform exposes a webhook endpoint at `/webhooks/buttondown/` that Buttondown uses to notify the platform when a subscriber unsubscribes.
+
+To set it up:
+
+1. Go to **Settings → Webhooks** in the Buttondown dashboard.
+2. Add the production URL: `https://djangonaut.space/webhooks/buttondown/`
+3. Enable the **subscriber.unsubscribed** event.
+4. Copy the generated webhook secret.
+
+| Variable | Description |
+|---|---|
+| `BUTTONDOWN_WEBHOOK_SECRET` | Signing secret used to verify incoming webhook requests |
+
+## Bulk Initial Sync
+
+To sync all existing active users when first enabling the integration:
+
+```bash
+# Preview which users would be synced
+uv run python manage.py sync_buttondown --dry-run
+
+# Enqueue sync tasks for all active users
+uv run python manage.py sync_buttondown
+```
+
+Ongoing syncs are handled automatically on every user profile save.

--- a/home/integrations/buttondown/client.py
+++ b/home/integrations/buttondown/client.py
@@ -1,0 +1,85 @@
+import logging
+
+import requests
+from django.conf import settings
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+
+logger = logging.getLogger(__name__)
+
+BASE_URL = "https://api.buttondown.email/v1"
+
+
+class ButtondownClient:
+    """Low-level Buttondown API client."""
+
+    def __init__(self) -> None:
+        self.session = self._create_session()
+
+    def _create_session(self) -> requests.Session:
+        retry = Retry(
+            total=3,
+            backoff_factor=0.5,
+            status_forcelist=[429, 500, 502, 503, 504],
+            allowed_methods=["GET", "POST", "PATCH", "DELETE"],
+        )
+        adapter = HTTPAdapter(max_retries=retry)
+        session = requests.Session()
+        session.mount("https://", adapter)
+        return session
+
+    def _request(self, method: str, path: str, **kwargs) -> requests.Response:
+        """Send an authenticated request to Buttondown."""
+        kwargs.setdefault("timeout", 10)
+        headers = kwargs.pop("headers", {})
+        headers["Authorization"] = f"Token {settings.BUTTONDOWN_API_KEY}"
+        url = f"{BASE_URL}{path}"
+        try:
+            response = self.session.request(method, url, headers=headers, **kwargs)
+            if response.status_code == 429:
+                logger.error("Buttondown rate limit exceeded")
+            response.raise_for_status()
+            return response
+        except requests.RequestException:
+            logger.exception("Buttondown API request failed: %s %s", method, url)
+            raise
+
+    def get_subscriber_by_email(self, email: str) -> dict | None:
+        """
+        Look up a subscriber by email address.
+
+        Returns the subscriber dict if found, or None if not found.
+        """
+        response = self._request("GET", "/subscribers", params={"email": email})
+        results = response.json().get("results", [])
+        return results[0] if results else None
+
+    def create_subscriber(self, email: str, tags: list[str]) -> dict:
+        """
+        Create a new subscriber.
+
+        Returns the created subscriber dict (including 'id' UUID).
+        """
+        response = self._request(
+            "POST",
+            "/subscribers",
+            json={"email": email, "tags": tags},
+        )
+        return response.json()
+
+    def patch_subscriber(self, subscriber_id: str, payload: dict) -> dict:
+        """
+        Partially update a subscriber.
+
+        Returns the updated subscriber dict.
+        """
+        response = self._request(
+            "PATCH",
+            f"/subscribers/{subscriber_id}",
+            json=payload,
+        )
+        return response.json()
+
+    def delete_subscriber(self, subscriber_id: str) -> None:
+        """Delete a subscriber from Buttondown (204 No Content on success)."""
+        self._request("DELETE", f"/subscribers/{subscriber_id}")

--- a/home/integrations/buttondown/client.py
+++ b/home/integrations/buttondown/client.py
@@ -40,8 +40,13 @@ class ButtondownClient:
                 logger.error("Buttondown rate limit exceeded")
             response.raise_for_status()
             return response
-        except requests.RequestException:
-            logger.exception("Buttondown API request failed: %s %s", method, url)
+        except requests.RequestException as exc:
+            if not (
+                isinstance(exc, requests.HTTPError)
+                and exc.response is not None
+                and exc.response.status_code == 404
+            ):
+                logger.exception("Buttondown API request failed: %s %s", method, url)
             raise
 
     def get_subscriber_by_email(self, email: str) -> dict | None:
@@ -50,9 +55,13 @@ class ButtondownClient:
 
         Returns the subscriber dict if found, or None if not found.
         """
-        response = self._request("GET", "/subscribers", params={"email": email})
-        results = response.json().get("results", [])
-        return results[0] if results else None
+        try:
+            response = self._request("GET", f"/subscribers/{email}")
+        except requests.HTTPError as exc:
+            if exc.response is not None and exc.response.status_code == 404:
+                return None
+            raise
+        return response.json()
 
     def create_subscriber(self, email: str, tags: list[str]) -> dict:
         """
@@ -63,7 +72,7 @@ class ButtondownClient:
         response = self._request(
             "POST",
             "/subscribers",
-            json={"email": email, "tags": tags},
+            json={"email_address": email, "tags": tags, "type": "regular"},
         )
         return response.json()
 

--- a/home/integrations/buttondown/service.py
+++ b/home/integrations/buttondown/service.py
@@ -2,6 +2,7 @@ import logging
 
 from django.conf import settings
 
+from accounts.models import ButtondownAccount
 from home import constants
 from home.integrations.buttondown.client import ButtondownClient
 
@@ -34,7 +35,7 @@ ROLE_TAG_MAP: dict[str, str] = {
 
 def buttondown_enabled() -> bool:
     """Check whether Buttondown integration is configured."""
-    return bool(getattr(settings, "BUTTONDOWN_API_KEY", ""))
+    return bool(settings.BUTTONDOWN_API_KEY)
 
 
 def get_tags_for_user(user) -> list[str]:
@@ -44,8 +45,6 @@ def get_tags_for_user(user) -> list[str]:
     Does NOT include the "website" tag — callers add it only on first creation
     when the user did not already exist in Buttondown.
     """
-    from home.models import SessionMembership
-
     tags: list[str] = []
 
     # Interested-in tags
@@ -57,7 +56,7 @@ def get_tags_for_user(user) -> list[str]:
 
     # Accepted memberships (single query, iterated twice)
     accepted_memberships = list(
-        SessionMembership.objects.filter(user=user).accepted().select_related("session")
+        user.session_memberships.accepted().select_related("session")
     )
 
     # Session tags
@@ -101,22 +100,21 @@ class ButtondownService:
         First sync: look up by email; create or link existing subscriber.
         Subsequent sync: update tags or unsubscribe based on newsletter preference.
         """
-        from accounts.models import ButtondownAccount
-
         try:
             bd_account = user.buttondown_account
         except ButtondownAccount.DoesNotExist:
             bd_account = None
 
-        if bd_account is None:
-            self._first_sync(user)
-        else:
-            self._subsequent_sync(user, bd_account)
+        try:
+            if bd_account is None:
+                self._first_sync(user)
+            else:
+                self._subsequent_sync(user, bd_account)
+        except Exception:
+            logger.exception("Failed to sync user %s to Buttondown", user.pk)
 
     def _first_sync(self, user) -> None:
         """Handle first-time sync for a user with no ButtondownAccount."""
-        from accounts.models import ButtondownAccount
-
         existing = self.client.get_subscriber_by_email(user.email)
 
         if existing:
@@ -162,13 +160,16 @@ class ButtondownService:
 
     def remove_user(self, buttondown_identifier: str) -> None:
         """Delete a subscriber from Buttondown by their stored UUID."""
-        self.client.delete_subscriber(buttondown_identifier)
-        logger.info("Deleted Buttondown subscriber %s", buttondown_identifier)
+        try:
+            self.client.delete_subscriber(buttondown_identifier)
+            logger.info("Deleted Buttondown subscriber %s", buttondown_identifier)
+        except Exception:
+            logger.exception(
+                "Failed to remove Buttondown subscriber %s", buttondown_identifier
+            )
 
     def remove_user_for_user(self, user) -> None:
         """Look up a user's ButtondownAccount and delete their subscriber record."""
-        from accounts.models import ButtondownAccount
-
         try:
             bd_identifier = user.buttondown_account.buttondown_identifier
         except ButtondownAccount.DoesNotExist:

--- a/home/integrations/buttondown/service.py
+++ b/home/integrations/buttondown/service.py
@@ -1,0 +1,179 @@
+import logging
+
+from django.conf import settings
+
+from home import constants
+from home.integrations.buttondown.client import ButtondownClient
+
+logger = logging.getLogger(__name__)
+
+SESSION_SLUG_TO_TAG: dict[str, str] = {
+    "2023-pilot-session": "Session 0",
+    "2024-session-1": "Session 1",
+    "2024-session-2": "Session 2",
+    "2024-session-3": "Session 3",
+    "2025-session-4": "Session 4",
+    "2025-session-5": "Session 5",
+    "2026-session-6": "Session 6",
+}
+
+INTERESTED_IN_TAG_MAP: dict[str, str] = {
+    constants.DJANGONAUT: "Interested Djangonaut",
+    constants.CAPTAIN: "Interested Captain",
+    constants.NAVIGATOR: "Interested Navigator",
+    constants.ORGANIZER: "Interested Organizer",
+}
+
+ROLE_TAG_MAP: dict[str, str] = {
+    constants.DJANGONAUT: "Djangonaut",
+    constants.CAPTAIN: "Captain",
+    constants.NAVIGATOR: "Navigator",
+    constants.ORGANIZER: "Organizer",
+}
+
+
+def buttondown_enabled() -> bool:
+    """Check whether Buttondown integration is configured."""
+    return bool(getattr(settings, "BUTTONDOWN_API_KEY", ""))
+
+
+def get_tags_for_user(user) -> list[str]:
+    """
+    Compute the complete list of Buttondown tags for a user.
+
+    Does NOT include the "website" tag — callers add it only on first creation
+    when the user did not already exist in Buttondown.
+    """
+    from home.models import SessionMembership
+
+    tags: list[str] = []
+
+    # Interested-in tags
+    interested_in = getattr(user.profile, "interested_in", None) or []
+    for role in interested_in:
+        tag = INTERESTED_IN_TAG_MAP.get(role)
+        if tag:
+            tags.append(tag)
+
+    # Accepted memberships (single query, iterated twice)
+    accepted_memberships = list(
+        SessionMembership.objects.filter(user=user).accepted().select_related("session")
+    )
+
+    # Session tags
+    seen_session_tags: set[str] = set()
+    for membership in accepted_memberships:
+        session_tag = SESSION_SLUG_TO_TAG.get(membership.session.slug)
+        if session_tag and session_tag not in seen_session_tags:
+            tags.append(session_tag)
+            seen_session_tags.add(session_tag)
+
+    # Role tags (deduplicated, sorted for stable ordering)
+    role_tags_present: set[str] = set()
+    for membership in accepted_memberships:
+        role_tag = ROLE_TAG_MAP.get(membership.role)
+        if role_tag:
+            role_tags_present.add(role_tag)
+    tags.extend(sorted(role_tags_present))
+
+    # Admin tag
+    if user.is_superuser:
+        tags.append("Admin")
+
+    # "In Community" composite tag
+    community_roles = {"Djangonaut", "Navigator", "Captain", "Organizer"}
+    if role_tags_present & community_roles:
+        tags.append("In Community")
+
+    return tags
+
+
+class ButtondownService:
+    """High-level service for syncing users to Buttondown."""
+
+    def __init__(self) -> None:
+        self.client = ButtondownClient()
+
+    def sync_user(self, user) -> None:
+        """
+        Sync a single user to Buttondown.
+
+        First sync: look up by email; create or link existing subscriber.
+        Subsequent sync: update tags or unsubscribe based on newsletter preference.
+        """
+        from accounts.models import ButtondownAccount
+
+        try:
+            bd_account = user.buttondown_account
+        except ButtondownAccount.DoesNotExist:
+            bd_account = None
+
+        if bd_account is None:
+            self._first_sync(user)
+        else:
+            self._subsequent_sync(user, bd_account)
+
+    def _first_sync(self, user) -> None:
+        """Handle first-time sync for a user with no ButtondownAccount."""
+        from accounts.models import ButtondownAccount
+
+        existing = self.client.get_subscriber_by_email(user.email)
+
+        if existing:
+            # Subscriber already existed in Buttondown — link and update tags
+            subscriber_id = existing["id"]
+            ButtondownAccount.objects.create(
+                user=user, buttondown_identifier=subscriber_id
+            )
+            user.profile.receiving_newsletter = True
+            user.profile.save(update_fields=["receiving_newsletter"])
+            tags = get_tags_for_user(user)
+            self.client.patch_subscriber(subscriber_id, {"tags": tags})
+            logger.info("Linked existing Buttondown subscriber for user %s", user.pk)
+        else:
+            # New subscriber — add "website" tag to indicate origin
+            tags = get_tags_for_user(user)
+            tags.insert(0, "website")
+            data = self.client.create_subscriber(user.email, tags)
+            subscriber_id = data["id"]
+            ButtondownAccount.objects.create(
+                user=user, buttondown_identifier=subscriber_id
+            )
+            logger.info("Created new Buttondown subscriber for user %s", user.pk)
+
+    def _subsequent_sync(self, user, bd_account) -> None:
+        """Handle ongoing sync for a user with an existing ButtondownAccount."""
+        subscriber_id = bd_account.buttondown_identifier
+
+        if not user.profile.receiving_newsletter:
+            self.client.patch_subscriber(
+                subscriber_id, {"subscriber_type": "unsubscribed"}
+            )
+            logger.info("Unsubscribed Buttondown subscriber for user %s", user.pk)
+        else:
+            tags = get_tags_for_user(user)
+            self.client.patch_subscriber(
+                subscriber_id,
+                {"tags": tags, "subscriber_type": "regular"},
+            )
+            logger.info("Updated Buttondown tags for user %s", user.pk)
+
+        bd_account.save()  # Touch last_updated via auto_now
+
+    def remove_user(self, buttondown_identifier: str) -> None:
+        """Delete a subscriber from Buttondown by their stored UUID."""
+        self.client.delete_subscriber(buttondown_identifier)
+        logger.info("Deleted Buttondown subscriber %s", buttondown_identifier)
+
+    def remove_user_for_user(self, user) -> None:
+        """Look up a user's ButtondownAccount and delete their subscriber record."""
+        from accounts.models import ButtondownAccount
+
+        try:
+            bd_identifier = user.buttondown_account.buttondown_identifier
+        except ButtondownAccount.DoesNotExist:
+            return
+        self.remove_user(bd_identifier)
+
+
+buttondown_service = ButtondownService()

--- a/home/integrations/buttondown/service.py
+++ b/home/integrations/buttondown/service.py
@@ -1,8 +1,9 @@
 import logging
 
 from django.conf import settings
+from requests import HTTPError
 
-from accounts.models import ButtondownAccount
+from accounts.models import ButtondownAccount, UserProfile
 from home import constants
 from home.integrations.buttondown.client import ButtondownClient
 
@@ -97,66 +98,76 @@ class ButtondownService:
         """
         Sync a single user to Buttondown.
 
-        First sync: look up by email; create or link existing subscriber.
-        Subsequent sync: update tags or unsubscribe based on newsletter preference.
+        Determines the correct action based on whether a subscriber ID is already
+        known. If not (new user or account without an ID), it looks up the subscriber
+        by email and links them, or creates a new one. If the ID is known, it updates
+        tags or subscription status.
         """
         try:
             bd_account = user.buttondown_account
         except ButtondownAccount.DoesNotExist:
             bd_account = None
 
+        subscriber_id = bd_account.buttondown_identifier if bd_account else None
+
         try:
-            if bd_account is None:
-                self._first_sync(user)
-            else:
-                self._subsequent_sync(user, bd_account)
+            if subscriber_id:
+                try:
+                    if not user.profile.receiving_newsletter:
+                        subscriber_type = "unsubscribed"
+                    else:
+                        subscriber_type = "regular"
+                    tags = get_tags_for_user(user)
+                    self.client.patch_subscriber(
+                        subscriber_id,
+                        {"tags": tags, "type": subscriber_type},
+                    )
+                except HTTPError as exc:
+                    if exc.response is not None and exc.response.status_code == 404:
+                        logger.info(
+                            "Missing Buttondown subscriber for user %s", user.pk
+                        )
+                        subscriber_id = None
+                    else:
+                        raise
+
+            if not subscriber_id:
+                self._resolve_and_link(user, bd_account)
+                return
+
+            bd_account.save()  # Touch last_updated via auto_now
         except Exception:
             logger.exception("Failed to sync user %s to Buttondown", user.pk)
 
-    def _first_sync(self, user) -> None:
-        """Handle first-time sync for a user with no ButtondownAccount."""
+    def _resolve_and_link(self, user, bd_account: "ButtondownAccount | None") -> None:
+        """
+        Resolve a subscriber ID by looking up the user's email, then link or create.
+
+        Used when no subscriber ID is available — either because there is no
+        ButtondownAccount yet, or because the account exists without an identifier.
+        """
         existing = self.client.get_subscriber_by_email(user.email)
 
         if existing:
-            # Subscriber already existed in Buttondown — link and update tags
             subscriber_id = existing["id"]
-            ButtondownAccount.objects.create(
-                user=user, buttondown_identifier=subscriber_id
+            ButtondownAccount.objects.update_or_create(
+                user=user, defaults={"buttondown_identifier": subscriber_id}
             )
-            user.profile.receiving_newsletter = True
-            user.profile.save(update_fields=["receiving_newsletter"])
+            UserProfile.objects.filter(user=user).update(receiving_newsletter=True)
             tags = get_tags_for_user(user)
-            self.client.patch_subscriber(subscriber_id, {"tags": tags})
+            self.client.patch_subscriber(
+                subscriber_id, {"tags": tags, "type": "regular"}
+            )
             logger.info("Linked existing Buttondown subscriber for user %s", user.pk)
         else:
-            # New subscriber — add "website" tag to indicate origin
             tags = get_tags_for_user(user)
             tags.insert(0, "website")
             data = self.client.create_subscriber(user.email, tags)
             subscriber_id = data["id"]
-            ButtondownAccount.objects.create(
-                user=user, buttondown_identifier=subscriber_id
+            ButtondownAccount.objects.update_or_create(
+                user=user, defaults={"buttondown_identifier": subscriber_id}
             )
             logger.info("Created new Buttondown subscriber for user %s", user.pk)
-
-    def _subsequent_sync(self, user, bd_account) -> None:
-        """Handle ongoing sync for a user with an existing ButtondownAccount."""
-        subscriber_id = bd_account.buttondown_identifier
-
-        if not user.profile.receiving_newsletter:
-            self.client.patch_subscriber(
-                subscriber_id, {"subscriber_type": "unsubscribed"}
-            )
-            logger.info("Unsubscribed Buttondown subscriber for user %s", user.pk)
-        else:
-            tags = get_tags_for_user(user)
-            self.client.patch_subscriber(
-                subscriber_id,
-                {"tags": tags, "subscriber_type": "regular"},
-            )
-            logger.info("Updated Buttondown tags for user %s", user.pk)
-
-        bd_account.save()  # Touch last_updated via auto_now
 
     def remove_user(self, buttondown_identifier: str) -> None:
         """Delete a subscriber from Buttondown by their stored UUID."""

--- a/home/integrations/buttondown/webhook.py
+++ b/home/integrations/buttondown/webhook.py
@@ -1,0 +1,98 @@
+import hashlib
+import hmac
+import json
+import logging
+
+from django.conf import settings
+from django.http import (
+    HttpRequest,
+    HttpResponse,
+    HttpResponseBadRequest,
+    HttpResponseForbidden,
+)
+from django.views.decorators.csrf import csrf_exempt
+from django.views.decorators.http import require_POST
+
+from accounts.models import ButtondownAccount, UserProfile
+
+logger = logging.getLogger(__name__)
+
+
+def _verify_signature(body: bytes, signature_header: str) -> bool:
+    """
+    Verify a Buttondown webhook signature.
+
+    Buttondown sends 'X-Buttondown-Signature: sha256=<hexdigest>'
+    computed over the raw request body using the webhook secret.
+    """
+    secret = getattr(settings, "BUTTONDOWN_WEBHOOK_SECRET", "") or ""
+    if not secret:
+        return False
+
+    if not signature_header.startswith("sha256="):
+        return False
+
+    provided = signature_header[len("sha256=") :]
+    expected = hmac.new(
+        secret.encode("utf-8"),
+        body,
+        hashlib.sha256,
+    ).hexdigest()
+
+    return hmac.compare_digest(provided, expected)
+
+
+def _handle_unsubscribed(payload: dict) -> None:
+    """Set receiving_newsletter=False for the unsubscribed subscriber."""
+    subscriber_id = (payload.get("data") or {}).get("subscriber", "")
+    if not subscriber_id:
+        logger.warning("subscriber.unsubscribed webhook missing subscriber ID")
+        return
+
+    try:
+        bd_account = ButtondownAccount.objects.get(buttondown_identifier=subscriber_id)
+    except ButtondownAccount.DoesNotExist:
+        logger.info(
+            "subscriber.unsubscribed for unknown subscriber %s; ignoring",
+            subscriber_id,
+        )
+        return
+
+    # QuerySet.update() bypasses post_save so the signal doesn't enqueue
+    # a redundant sync back to Buttondown.
+    updated = UserProfile.objects.filter(
+        user=bd_account.user,
+        receiving_newsletter=True,
+    ).update(receiving_newsletter=False)
+
+    if updated:
+        logger.info(
+            "Set receiving_newsletter=False for user %s via Buttondown webhook",
+            bd_account.user_id,
+        )
+
+
+@csrf_exempt
+@require_POST
+def buttondown_webhook(request: HttpRequest) -> HttpResponse:
+    """
+    Handle incoming Buttondown webhook events.
+
+    Handles subscriber.unsubscribed by setting UserProfile.receiving_newsletter=False.
+    All requests are verified against BUTTONDOWN_WEBHOOK_SECRET before processing.
+    """
+    signature = request.headers.get("X-Buttondown-Signature", "")
+    if not _verify_signature(request.body, signature):
+        return HttpResponseForbidden("Invalid signature")
+
+    try:
+        payload = json.loads(request.body)
+    except json.JSONDecodeError:
+        return HttpResponseBadRequest("Invalid JSON")
+
+    event_type = payload.get("event_type", "")
+
+    if event_type == "subscriber.unsubscribed":
+        _handle_unsubscribed(payload)
+
+    return HttpResponse(status=200)

--- a/home/integrations/buttondown/webhook.py
+++ b/home/integrations/buttondown/webhook.py
@@ -25,7 +25,7 @@ def _verify_signature(body: bytes, signature_header: str) -> bool:
     Buttondown sends 'X-Buttondown-Signature: sha256=<hexdigest>'
     computed over the raw request body using the webhook secret.
     """
-    secret = getattr(settings, "BUTTONDOWN_WEBHOOK_SECRET", "") or ""
+    secret = settings.BUTTONDOWN_WEBHOOK_SECRET
     if not secret:
         return False
 
@@ -92,7 +92,8 @@ def buttondown_webhook(request: HttpRequest) -> HttpResponse:
 
     event_type = payload.get("event_type", "")
 
-    if event_type == "subscriber.unsubscribed":
-        _handle_unsubscribed(payload)
+    match event_type:
+        case "subscriber.unsubscribed":
+            _handle_unsubscribed(payload)
 
     return HttpResponse(status=200)

--- a/home/tasks/sync_buttondown.py
+++ b/home/tasks/sync_buttondown.py
@@ -1,0 +1,60 @@
+import logging
+
+from django.contrib.auth import get_user_model
+from django_tasks import task
+
+from home.integrations.buttondown.service import buttondown_enabled, buttondown_service
+
+logger = logging.getLogger(__name__)
+
+User = get_user_model()
+
+
+@task()
+def sync_user_to_buttondown(user_id: int) -> None:
+    """
+    Sync a single user's newsletter subscription state to Buttondown.
+
+    Safely handles missing credentials, deleted users, and API failures.
+    """
+    if not buttondown_enabled():
+        logger.warning(
+            "Buttondown API key not configured; skipping sync for user %s", user_id
+        )
+        return
+
+    try:
+        user = User.objects.select_related("profile", "buttondown_account").get(
+            pk=user_id
+        )
+    except User.DoesNotExist:
+        logger.warning("User %s no longer exists; skipping Buttondown sync", user_id)
+        return
+
+    try:
+        buttondown_service.sync_user(user)
+    except Exception:
+        logger.exception("Failed to sync user %s to Buttondown", user_id)
+
+
+@task()
+def remove_user_from_buttondown(buttondown_identifier: str) -> None:
+    """
+    Remove a subscriber from Buttondown by their stored UUID.
+
+    Accepts the identifier directly (not user_id) because the user may already
+    be deleted from the database when this task runs.
+    """
+    if not buttondown_enabled():
+        logger.warning(
+            "Buttondown API key not configured; skipping removal of %s",
+            buttondown_identifier,
+        )
+        return
+
+    try:
+        buttondown_service.remove_user(buttondown_identifier)
+    except Exception:
+        logger.exception(
+            "Failed to remove Buttondown subscriber %s", buttondown_identifier
+        )

--- a/home/tasks/sync_buttondown.py
+++ b/home/tasks/sync_buttondown.py
@@ -32,21 +32,3 @@ def sync_user_to_buttondown(user_id: int) -> None:
         return
 
     buttondown_service.sync_user(user)
-
-
-@task()
-def remove_user_from_buttondown(buttondown_identifier: str) -> None:
-    """
-    Remove a subscriber from Buttondown by their stored UUID.
-
-    Accepts the identifier directly (not user_id) because the user may already
-    be deleted from the database when this task runs.
-    """
-    if not buttondown_enabled():
-        logger.warning(
-            "Buttondown API key not configured; skipping removal of %s",
-            buttondown_identifier,
-        )
-        return
-
-    buttondown_service.remove_user(buttondown_identifier)

--- a/home/tasks/sync_buttondown.py
+++ b/home/tasks/sync_buttondown.py
@@ -31,10 +31,7 @@ def sync_user_to_buttondown(user_id: int) -> None:
         logger.warning("User %s no longer exists; skipping Buttondown sync", user_id)
         return
 
-    try:
-        buttondown_service.sync_user(user)
-    except Exception:
-        logger.exception("Failed to sync user %s to Buttondown", user_id)
+    buttondown_service.sync_user(user)
 
 
 @task()
@@ -52,9 +49,4 @@ def remove_user_from_buttondown(buttondown_identifier: str) -> None:
         )
         return
 
-    try:
-        buttondown_service.remove_user(buttondown_identifier)
-    except Exception:
-        logger.exception(
-            "Failed to remove Buttondown subscriber %s", buttondown_identifier
-        )
+    buttondown_service.remove_user(buttondown_identifier)

--- a/home/tests/test_buttondown.py
+++ b/home/tests/test_buttondown.py
@@ -1,10 +1,9 @@
 """
 Tests for Buttondown newsletter sync: ButtondownClient, service layer,
-background tasks, signal handlers, and the management command.
+and background tasks.
 """
 
 import json
-from io import StringIO
 from unittest.mock import patch
 
 import requests
@@ -30,11 +29,6 @@ from home.tasks.sync_buttondown import (
 BD_SETTINGS = {"BUTTONDOWN_API_KEY": "test-api-key"}
 
 
-# ---------------------------------------------------------------------------
-# buttondown_enabled()
-# ---------------------------------------------------------------------------
-
-
 class ButtondownEnabledTests(TestCase):
     @override_settings(BUTTONDOWN_API_KEY="key")
     def test_returns_true_when_api_key_present(self):
@@ -47,11 +41,6 @@ class ButtondownEnabledTests(TestCase):
     @override_settings(BUTTONDOWN_API_KEY=None)
     def test_returns_false_when_api_key_none(self):
         self.assertFalse(buttondown_enabled())
-
-
-# ---------------------------------------------------------------------------
-# ButtondownClient
-# ---------------------------------------------------------------------------
 
 
 _BASE_URL = "https://api.buttondown.email/v1"
@@ -152,11 +141,6 @@ class ButtondownClientTests(TestCase):
         self.assertTrue(auth.startswith("Token "))
 
 
-# ---------------------------------------------------------------------------
-# get_tags_for_user()
-# ---------------------------------------------------------------------------
-
-
 class GetTagsForUserTests(TestCase):
     def _make_user(self, interested_in=None, is_superuser=False):
         user = UserFactory.create(is_superuser=is_superuser)
@@ -208,27 +192,19 @@ class GetTagsForUserTests(TestCase):
         self.assertNotIn("Session 0", tags)
         self.assertNotIn("Session 1", tags)
 
-    def test_role_tag_djangonaut(self):
+    def test_role_tags_for_all_roles(self):
         user = self._make_user()
         SessionMembershipFactory.create(
             user=user, role=constants.DJANGONAUT, accepted=True
         )
-        self.assertIn("Djangonaut", get_tags_for_user(user))
-
-    def test_role_tag_navigator(self):
-        user = self._make_user()
         SessionMembershipFactory.create(user=user, role=constants.NAVIGATOR)
-        self.assertIn("Navigator", get_tags_for_user(user))
-
-    def test_role_tag_captain(self):
-        user = self._make_user()
         SessionMembershipFactory.create(user=user, role=constants.CAPTAIN)
-        self.assertIn("Captain", get_tags_for_user(user))
-
-    def test_role_tag_organizer(self):
-        user = self._make_user()
         SessionMembershipFactory.create(user=user, role=constants.ORGANIZER)
-        self.assertIn("Organizer", get_tags_for_user(user))
+        tags = get_tags_for_user(user)
+        self.assertIn("Djangonaut", tags)
+        self.assertIn("Navigator", tags)
+        self.assertIn("Captain", tags)
+        self.assertIn("Organizer", tags)
 
     def test_role_tags_deduplicated_across_sessions(self):
         user = self._make_user()
@@ -280,11 +256,6 @@ class GetTagsForUserTests(TestCase):
         user = self._make_user(interested_in=[])
         tags = get_tags_for_user(user)
         self.assertFalse(any(t.startswith("Interested") for t in tags))
-
-
-# ---------------------------------------------------------------------------
-# ButtondownService._first_sync
-# ---------------------------------------------------------------------------
 
 
 class ButtondownServiceFirstSyncTests(TestCase):
@@ -399,10 +370,14 @@ class ButtondownServiceFirstSyncTests(TestCase):
         self.user.profile.refresh_from_db()
         self.assertFalse(self.user.profile.receiving_newsletter)
 
-
-# ---------------------------------------------------------------------------
-# ButtondownService._subsequent_sync
-# ---------------------------------------------------------------------------
+    @override_settings(**BD_SETTINGS)
+    def test_sync_user_does_not_raise_on_api_error(self):
+        with patch.object(
+            buttondown_service.client,
+            "get_subscriber_by_email",
+            side_effect=Exception("API down"),
+        ):
+            buttondown_service.sync_user(self.user)
 
 
 class ButtondownServiceSubsequentSyncTests(TestCase):
@@ -453,11 +428,6 @@ class ButtondownServiceSubsequentSyncTests(TestCase):
         self.assertGreaterEqual(self.bd_account.last_updated, original_updated)
 
 
-# ---------------------------------------------------------------------------
-# ButtondownService.remove_user
-# ---------------------------------------------------------------------------
-
-
 class ButtondownServiceRemoveUserTests(TestCase):
     @override_settings(**BD_SETTINGS)
     def test_remove_user_calls_delete_subscriber(self):
@@ -487,10 +457,14 @@ class ButtondownServiceRemoveUserTests(TestCase):
 
         mock_remove.assert_not_called()
 
-
-# ---------------------------------------------------------------------------
-# sync_user_to_buttondown task
-# ---------------------------------------------------------------------------
+    @override_settings(**BD_SETTINGS)
+    def test_remove_user_does_not_raise_on_api_error(self):
+        with patch.object(
+            buttondown_service.client,
+            "delete_subscriber",
+            side_effect=Exception("API down"),
+        ):
+            buttondown_service.remove_user("bd-uuid")
 
 
 class SyncUserToButtondownTaskTests(TestCase):
@@ -517,20 +491,6 @@ class SyncUserToButtondownTaskTests(TestCase):
         mock_sync.assert_called_once()
         self.assertEqual(mock_sync.call_args.args[0].pk, user.pk)
 
-    @override_settings(**BD_SETTINGS)
-    def test_handles_service_exception_without_raising(self):
-        user = UserFactory.create()
-        with patch.object(
-            buttondown_service, "sync_user", side_effect=Exception("API down")
-        ):
-            # Should not raise
-            sync_user_to_buttondown.call(user_id=user.pk)
-
-
-# ---------------------------------------------------------------------------
-# remove_user_from_buttondown task
-# ---------------------------------------------------------------------------
-
 
 class RemoveUserFromButtondownTaskTests(TestCase):
     @override_settings(BUTTONDOWN_API_KEY="")
@@ -546,139 +506,3 @@ class RemoveUserFromButtondownTaskTests(TestCase):
             remove_user_from_buttondown.call(buttondown_identifier="bd-uuid")
 
         mock_remove.assert_called_once_with("bd-uuid")
-
-    @override_settings(**BD_SETTINGS)
-    def test_handles_service_exception_without_raising(self):
-        with patch.object(
-            buttondown_service, "remove_user", side_effect=Exception("API down")
-        ):
-            # Should not raise
-            remove_user_from_buttondown.call(buttondown_identifier="bd-uuid")
-
-
-# ---------------------------------------------------------------------------
-# Signal handlers
-# ---------------------------------------------------------------------------
-
-
-class ButtondownSignalTests(TestCase):
-    """
-    Signal tests use ImmediateBackend (configured in test settings), so
-    enqueued tasks run synchronously. We mock at the service layer to verify
-    the full signal→task→service chain fires correctly.
-    """
-
-    @override_settings(**BD_SETTINGS)
-    def test_profile_save_triggers_sync_when_account_exists(self):
-        user = UserFactory.create()
-        ButtondownAccount.objects.create(
-            user=user, buttondown_identifier="bd-uuid-signal"
-        )
-
-        with patch.object(buttondown_service, "sync_user") as mock_sync:
-            user.profile.bio = "updated"
-            user.profile.save()
-
-        mock_sync.assert_called_once()
-        self.assertEqual(mock_sync.call_args.args[0].pk, user.pk)
-
-    @override_settings(**BD_SETTINGS)
-    def test_profile_save_always_triggers_sync_when_configured(self):
-        user = UserFactory.create()
-        # No ButtondownAccount, receiving_newsletter=False — still syncs
-        with patch.object(buttondown_service, "sync_user") as mock_sync:
-            user.profile.bio = "updated"
-            user.profile.save()
-
-        mock_sync.assert_called_once()
-        self.assertEqual(mock_sync.call_args.args[0].pk, user.pk)
-
-    @override_settings(**BD_SETTINGS)
-    def test_profile_save_triggers_sync_when_opting_in_with_no_account(self):
-        user = UserFactory.create()
-        # No ButtondownAccount but user opts in — trigger first sync
-        with patch.object(buttondown_service, "sync_user") as mock_sync:
-            user.profile.receiving_newsletter = True
-            user.profile.save()
-
-        mock_sync.assert_called_once()
-        self.assertEqual(mock_sync.call_args.args[0].pk, user.pk)
-
-    @override_settings(**BD_SETTINGS)
-    def test_new_signup_triggers_sync(self):
-        # Create via ORM directly so post_save signals fire (factory mutes them)
-        from django.contrib.auth import get_user_model
-
-        User = get_user_model()
-
-        with patch.object(buttondown_service, "sync_user") as mock_sync:
-            User.objects.create_user(username="newuser", email="new@example.com")
-
-        mock_sync.assert_called_once()
-
-    @override_settings(BUTTONDOWN_API_KEY="")
-    def test_profile_save_does_not_sync_when_not_configured(self):
-        user = UserFactory.create()
-        ButtondownAccount.objects.create(
-            user=user, buttondown_identifier="bd-uuid-signal"
-        )
-
-        with patch.object(buttondown_service, "sync_user") as mock_sync:
-            user.profile.bio = "updated"
-            user.profile.save()
-
-        mock_sync.assert_not_called()
-
-
-# ---------------------------------------------------------------------------
-# sync_buttondown management command
-# ---------------------------------------------------------------------------
-
-
-class SyncButtondownCommandTests(TestCase):
-    """
-    Management command tests use ImmediateBackend, so enqueued tasks run
-    synchronously. We mock at the service layer to verify correct dispatch.
-    """
-
-    @override_settings(**BD_SETTINGS)
-    def test_syncs_active_users(self):
-        from django.core.management import call_command
-
-        active1 = UserFactory.create(is_active=True)
-        active2 = UserFactory.create(is_active=True)
-        UserFactory.create(is_active=False)
-
-        with patch.object(buttondown_service, "sync_user") as mock_sync:
-            call_command("sync_buttondown", stdout=StringIO(), stderr=StringIO())
-
-        synced_pks = {c.args[0].pk for c in mock_sync.call_args_list}
-        self.assertIn(active1.pk, synced_pks)
-        self.assertIn(active2.pk, synced_pks)
-        self.assertEqual(mock_sync.call_count, 2)
-
-    @override_settings(**BD_SETTINGS)
-    def test_dry_run_does_not_sync(self):
-        from django.core.management import call_command
-
-        UserFactory.create(is_active=True)
-
-        with patch.object(buttondown_service, "sync_user") as mock_sync:
-            out = StringIO()
-            call_command("sync_buttondown", dry_run=True, stdout=out, stderr=StringIO())
-
-        mock_sync.assert_not_called()
-        self.assertIn("Dry run", out.getvalue())
-
-    @override_settings(BUTTONDOWN_API_KEY="")
-    def test_aborts_when_not_configured(self):
-        from django.core.management import call_command
-
-        UserFactory.create(is_active=True)
-
-        with patch.object(buttondown_service, "sync_user") as mock_sync:
-            err = StringIO()
-            call_command("sync_buttondown", stdout=StringIO(), stderr=err)
-
-        mock_sync.assert_not_called()
-        self.assertIn("BUTTONDOWN_API_KEY", err.getvalue())

--- a/home/tests/test_buttondown.py
+++ b/home/tests/test_buttondown.py
@@ -21,12 +21,16 @@ from home.integrations.buttondown.service import (
     buttondown_service,
     get_tags_for_user,
 )
-from home.tasks.sync_buttondown import (
-    remove_user_from_buttondown,
-    sync_user_to_buttondown,
-)
+from home.tasks.sync_buttondown import sync_user_to_buttondown
 
 BD_SETTINGS = {"BUTTONDOWN_API_KEY": "test-api-key"}
+
+
+def _make_response(status_code: int) -> requests.Response:
+    """Build a minimal requests.Response with a given status code."""
+    resp = requests.Response()
+    resp.status_code = status_code
+    return resp
 
 
 class ButtondownEnabledTests(TestCase):
@@ -54,7 +58,11 @@ class ButtondownClientTests(TestCase):
     @rsps.activate
     def test_get_subscriber_by_email_found(self):
         subscriber = {"id": "uuid-123", "email": "foo@example.com"}
-        rsps.add(rsps.GET, f"{_BASE_URL}/subscribers", json={"results": [subscriber]})
+        rsps.add(
+            rsps.GET,
+            f"{_BASE_URL}/subscribers/foo@example.com",
+            json=subscriber,
+        )
 
         result = self.bd_client.get_subscriber_by_email("foo@example.com")
 
@@ -63,7 +71,11 @@ class ButtondownClientTests(TestCase):
     @override_settings(**BD_SETTINGS)
     @rsps.activate
     def test_get_subscriber_by_email_not_found(self):
-        rsps.add(rsps.GET, f"{_BASE_URL}/subscribers", json={"results": []})
+        rsps.add(
+            rsps.GET,
+            f"{_BASE_URL}/subscribers/nobody@example.com",
+            status=404,
+        )
 
         result = self.bd_client.get_subscriber_by_email("nobody@example.com")
 
@@ -72,12 +84,16 @@ class ButtondownClientTests(TestCase):
     @override_settings(**BD_SETTINGS)
     @rsps.activate
     def test_get_subscriber_by_email_sends_correct_params(self):
-        rsps.add(rsps.GET, f"{_BASE_URL}/subscribers", json={"results": []})
+        rsps.add(
+            rsps.GET,
+            f"{_BASE_URL}/subscribers/foo@example.com",
+            json={"id": "uuid-123"},
+        )
 
         self.bd_client.get_subscriber_by_email("foo@example.com")
 
         req = rsps.calls[0].request
-        self.assertIn("email=foo%40example.com", req.url)
+        self.assertIn("/subscribers/foo@example.com", req.url)
         self.assertEqual(req.headers["Authorization"], "Token test-api-key")
 
     @override_settings(**BD_SETTINGS)
@@ -94,12 +110,19 @@ class ButtondownClientTests(TestCase):
 
         self.assertEqual(result["id"], "new-uuid")
         body = json.loads(rsps.calls[0].request.body)
-        self.assertEqual(body, {"email": "new@example.com", "tags": ["website"]})
+        self.assertEqual(
+            body,
+            {
+                "email_address": "new@example.com",
+                "tags": ["website"],
+                "type": "regular",
+            },
+        )
 
     @override_settings(**BD_SETTINGS)
     @rsps.activate
     def test_patch_subscriber(self):
-        payload = {"tags": ["Admin"], "subscriber_type": "regular"}
+        payload = {"tags": ["Admin"], "type": "regular"}
         rsps.add(
             rsps.PATCH,
             f"{_BASE_URL}/subscribers/uuid-123",
@@ -124,8 +147,8 @@ class ButtondownClientTests(TestCase):
     @override_settings(**BD_SETTINGS)
     @rsps.activate
     def test_request_raises_on_http_error(self):
-        # 404 is not in status_forcelist so retries don't fire; raise_for_status raises HTTPError
-        rsps.add(rsps.GET, f"{_BASE_URL}/subscribers", status=404)
+        # 400 is not in status_forcelist so retries don't fire; raise_for_status raises HTTPError
+        rsps.add(rsps.GET, f"{_BASE_URL}/subscribers/foo@example.com", status=400)
 
         with self.assertRaises(requests.HTTPError):
             self.bd_client.get_subscriber_by_email("foo@example.com")
@@ -133,7 +156,9 @@ class ButtondownClientTests(TestCase):
     @override_settings(**BD_SETTINGS)
     @rsps.activate
     def test_authorization_header_uses_token_scheme(self):
-        rsps.add(rsps.GET, f"{_BASE_URL}/subscribers", json={"results": []})
+        rsps.add(
+            rsps.GET, f"{_BASE_URL}/subscribers/x@example.com", json={"id": "uuid"}
+        )
 
         self.bd_client.get_subscriber_by_email("x@example.com")
 
@@ -380,6 +405,69 @@ class ButtondownServiceFirstSyncTests(TestCase):
             buttondown_service.sync_user(self.user)
 
 
+class ButtondownServiceAccountWithoutIdentifierTests(TestCase):
+    """Tests for when a ButtondownAccount exists but has no identifier yet."""
+
+    def setUp(self):
+        self.user = UserFactory.create()
+        self.user.profile.receiving_newsletter = False
+        self.user.profile.save()
+        self.bd_account = ButtondownAccount.objects.create(
+            user=self.user, buttondown_identifier=""
+        )
+
+    @override_settings(**BD_SETTINGS)
+    def test_links_existing_subscriber_when_account_has_no_id(self):
+        existing = {"id": "bd-uuid-found"}
+        with (
+            patch.object(
+                buttondown_service.client,
+                "get_subscriber_by_email",
+                return_value=existing,
+            ),
+            patch.object(buttondown_service.client, "patch_subscriber"),
+        ):
+            buttondown_service.sync_user(self.user)
+
+        self.bd_account.refresh_from_db()
+        self.assertEqual(self.bd_account.buttondown_identifier, "bd-uuid-found")
+
+    @override_settings(**BD_SETTINGS)
+    def test_creates_new_subscriber_when_account_has_no_id_and_not_found(self):
+        with (
+            patch.object(
+                buttondown_service.client,
+                "get_subscriber_by_email",
+                return_value=None,
+            ),
+            patch.object(
+                buttondown_service.client,
+                "create_subscriber",
+                return_value={"id": "bd-uuid-new"},
+            ),
+        ):
+            buttondown_service.sync_user(self.user)
+
+        self.bd_account.refresh_from_db()
+        self.assertEqual(self.bd_account.buttondown_identifier, "bd-uuid-new")
+
+    @override_settings(**BD_SETTINGS)
+    def test_sets_receiving_newsletter_true_when_linking_existing(self):
+        existing = {"id": "bd-uuid-found"}
+        with (
+            patch.object(
+                buttondown_service.client,
+                "get_subscriber_by_email",
+                return_value=existing,
+            ),
+            patch.object(buttondown_service.client, "patch_subscriber"),
+        ):
+            buttondown_service.sync_user(self.user)
+
+        self.user.profile.refresh_from_db()
+        self.assertTrue(self.user.profile.receiving_newsletter)
+
+
 class ButtondownServiceSubsequentSyncTests(TestCase):
     def setUp(self):
         self.user = UserFactory.create()
@@ -395,7 +483,7 @@ class ButtondownServiceSubsequentSyncTests(TestCase):
             buttondown_service.sync_user(self.user)
 
         payload = mock_patch.call_args.args[1]
-        self.assertEqual(payload["subscriber_type"], "regular")
+        self.assertEqual(payload["type"], "regular")
         self.assertIn("tags", payload)
 
     @override_settings(**BD_SETTINGS)
@@ -407,7 +495,13 @@ class ButtondownServiceSubsequentSyncTests(TestCase):
             buttondown_service.sync_user(self.user)
 
         payload = mock_patch.call_args.args[1]
-        self.assertEqual(payload, {"subscriber_type": "unsubscribed"})
+        self.assertEqual(
+            payload,
+            {
+                "type": "unsubscribed",
+                "tags": ["Interested Djangonaut"],
+            },
+        )
 
     @override_settings(**BD_SETTINGS)
     def test_subsequent_sync_calls_patch_with_correct_id(self):
@@ -426,6 +520,55 @@ class ButtondownServiceSubsequentSyncTests(TestCase):
 
         self.bd_account.refresh_from_db()
         self.assertGreaterEqual(self.bd_account.last_updated, original_updated)
+
+    @override_settings(**BD_SETTINGS)
+    def test_patch_404_falls_back_to_resolve_and_link_existing(self):
+        """Subscriber deleted from Buttondown; re-links when found by email."""
+        not_found = requests.HTTPError(response=_make_response(404))
+        existing = {"id": "bd-uuid-new"}
+        # First patch call raises 404; second (after re-link) succeeds.
+        with (
+            patch.object(
+                buttondown_service.client,
+                "patch_subscriber",
+                side_effect=[not_found, {"tags": []}],
+            ),
+            patch.object(
+                buttondown_service.client,
+                "get_subscriber_by_email",
+                return_value=existing,
+            ),
+        ):
+            buttondown_service.sync_user(self.user)
+
+        self.bd_account.refresh_from_db()
+        self.assertEqual(self.bd_account.buttondown_identifier, "bd-uuid-new")
+
+    @override_settings(**BD_SETTINGS)
+    def test_patch_404_creates_new_subscriber_when_not_found_by_email(self):
+        """Subscriber deleted from Buttondown and email lookup finds nothing."""
+        not_found = requests.HTTPError(response=_make_response(404))
+        with (
+            patch.object(
+                buttondown_service.client,
+                "patch_subscriber",
+                side_effect=not_found,
+            ),
+            patch.object(
+                buttondown_service.client,
+                "get_subscriber_by_email",
+                return_value=None,
+            ),
+            patch.object(
+                buttondown_service.client,
+                "create_subscriber",
+                return_value={"id": "bd-uuid-created"},
+            ),
+        ):
+            buttondown_service.sync_user(self.user)
+
+        self.bd_account.refresh_from_db()
+        self.assertEqual(self.bd_account.buttondown_identifier, "bd-uuid-created")
 
 
 class ButtondownServiceRemoveUserTests(TestCase):
@@ -490,19 +633,3 @@ class SyncUserToButtondownTaskTests(TestCase):
 
         mock_sync.assert_called_once()
         self.assertEqual(mock_sync.call_args.args[0].pk, user.pk)
-
-
-class RemoveUserFromButtondownTaskTests(TestCase):
-    @override_settings(BUTTONDOWN_API_KEY="")
-    def test_skips_when_not_configured(self):
-        with patch.object(buttondown_service, "remove_user") as mock_remove:
-            remove_user_from_buttondown.call(buttondown_identifier="bd-uuid")
-
-        mock_remove.assert_not_called()
-
-    @override_settings(**BD_SETTINGS)
-    def test_calls_service_remove_user(self):
-        with patch.object(buttondown_service, "remove_user") as mock_remove:
-            remove_user_from_buttondown.call(buttondown_identifier="bd-uuid")
-
-        mock_remove.assert_called_once_with("bd-uuid")

--- a/home/tests/test_buttondown.py
+++ b/home/tests/test_buttondown.py
@@ -1,0 +1,684 @@
+"""
+Tests for Buttondown newsletter sync: ButtondownClient, service layer,
+background tasks, signal handlers, and the management command.
+"""
+
+import json
+from io import StringIO
+from unittest.mock import patch
+
+import requests
+import responses as rsps
+from django.test import TestCase, override_settings
+
+from accounts.factories import UserFactory
+from accounts.models import ButtondownAccount
+from home import constants
+from home.factories import SessionFactory, SessionMembershipFactory
+from home.integrations.buttondown.client import ButtondownClient
+from home.integrations.buttondown.service import (
+    SESSION_SLUG_TO_TAG,
+    buttondown_enabled,
+    buttondown_service,
+    get_tags_for_user,
+)
+from home.tasks.sync_buttondown import (
+    remove_user_from_buttondown,
+    sync_user_to_buttondown,
+)
+
+BD_SETTINGS = {"BUTTONDOWN_API_KEY": "test-api-key"}
+
+
+# ---------------------------------------------------------------------------
+# buttondown_enabled()
+# ---------------------------------------------------------------------------
+
+
+class ButtondownEnabledTests(TestCase):
+    @override_settings(BUTTONDOWN_API_KEY="key")
+    def test_returns_true_when_api_key_present(self):
+        self.assertTrue(buttondown_enabled())
+
+    @override_settings(BUTTONDOWN_API_KEY="")
+    def test_returns_false_when_api_key_empty(self):
+        self.assertFalse(buttondown_enabled())
+
+    @override_settings(BUTTONDOWN_API_KEY=None)
+    def test_returns_false_when_api_key_none(self):
+        self.assertFalse(buttondown_enabled())
+
+
+# ---------------------------------------------------------------------------
+# ButtondownClient
+# ---------------------------------------------------------------------------
+
+
+_BASE_URL = "https://api.buttondown.email/v1"
+
+
+class ButtondownClientTests(TestCase):
+    def setUp(self):
+        self.bd_client = ButtondownClient()
+
+    @override_settings(**BD_SETTINGS)
+    @rsps.activate
+    def test_get_subscriber_by_email_found(self):
+        subscriber = {"id": "uuid-123", "email": "foo@example.com"}
+        rsps.add(rsps.GET, f"{_BASE_URL}/subscribers", json={"results": [subscriber]})
+
+        result = self.bd_client.get_subscriber_by_email("foo@example.com")
+
+        self.assertEqual(result, subscriber)
+
+    @override_settings(**BD_SETTINGS)
+    @rsps.activate
+    def test_get_subscriber_by_email_not_found(self):
+        rsps.add(rsps.GET, f"{_BASE_URL}/subscribers", json={"results": []})
+
+        result = self.bd_client.get_subscriber_by_email("nobody@example.com")
+
+        self.assertIsNone(result)
+
+    @override_settings(**BD_SETTINGS)
+    @rsps.activate
+    def test_get_subscriber_by_email_sends_correct_params(self):
+        rsps.add(rsps.GET, f"{_BASE_URL}/subscribers", json={"results": []})
+
+        self.bd_client.get_subscriber_by_email("foo@example.com")
+
+        req = rsps.calls[0].request
+        self.assertIn("email=foo%40example.com", req.url)
+        self.assertEqual(req.headers["Authorization"], "Token test-api-key")
+
+    @override_settings(**BD_SETTINGS)
+    @rsps.activate
+    def test_create_subscriber(self):
+        rsps.add(
+            rsps.POST,
+            f"{_BASE_URL}/subscribers",
+            json={"id": "new-uuid", "email": "new@example.com"},
+            status=201,
+        )
+
+        result = self.bd_client.create_subscriber("new@example.com", ["website"])
+
+        self.assertEqual(result["id"], "new-uuid")
+        body = json.loads(rsps.calls[0].request.body)
+        self.assertEqual(body, {"email": "new@example.com", "tags": ["website"]})
+
+    @override_settings(**BD_SETTINGS)
+    @rsps.activate
+    def test_patch_subscriber(self):
+        payload = {"tags": ["Admin"], "subscriber_type": "regular"}
+        rsps.add(
+            rsps.PATCH,
+            f"{_BASE_URL}/subscribers/uuid-123",
+            json={"id": "uuid-123", "tags": ["Admin"]},
+        )
+
+        result = self.bd_client.patch_subscriber("uuid-123", payload)
+
+        self.assertEqual(result["id"], "uuid-123")
+        body = json.loads(rsps.calls[0].request.body)
+        self.assertEqual(body, payload)
+
+    @override_settings(**BD_SETTINGS)
+    @rsps.activate
+    def test_delete_subscriber_returns_none(self):
+        rsps.add(rsps.DELETE, f"{_BASE_URL}/subscribers/uuid-123", status=204)
+
+        result = self.bd_client.delete_subscriber("uuid-123")
+
+        self.assertIsNone(result)
+
+    @override_settings(**BD_SETTINGS)
+    @rsps.activate
+    def test_request_raises_on_http_error(self):
+        # 404 is not in status_forcelist so retries don't fire; raise_for_status raises HTTPError
+        rsps.add(rsps.GET, f"{_BASE_URL}/subscribers", status=404)
+
+        with self.assertRaises(requests.HTTPError):
+            self.bd_client.get_subscriber_by_email("foo@example.com")
+
+    @override_settings(**BD_SETTINGS)
+    @rsps.activate
+    def test_authorization_header_uses_token_scheme(self):
+        rsps.add(rsps.GET, f"{_BASE_URL}/subscribers", json={"results": []})
+
+        self.bd_client.get_subscriber_by_email("x@example.com")
+
+        auth = rsps.calls[0].request.headers["Authorization"]
+        self.assertTrue(auth.startswith("Token "))
+
+
+# ---------------------------------------------------------------------------
+# get_tags_for_user()
+# ---------------------------------------------------------------------------
+
+
+class GetTagsForUserTests(TestCase):
+    def _make_user(self, interested_in=None, is_superuser=False):
+        user = UserFactory.create(is_superuser=is_superuser)
+        if interested_in is not None:
+            user.profile.interested_in = interested_in
+            user.profile.save()
+        return user
+
+    def test_interested_in_djangonaut_tag(self):
+        user = self._make_user(interested_in=[constants.DJANGONAUT])
+        self.assertIn("Interested Djangonaut", get_tags_for_user(user))
+
+    def test_interested_in_multiple_roles(self):
+        user = self._make_user(interested_in=[constants.CAPTAIN, constants.NAVIGATOR])
+        tags = get_tags_for_user(user)
+        self.assertIn("Interested Captain", tags)
+        self.assertIn("Interested Navigator", tags)
+
+    def test_unknown_interested_in_role_skipped(self):
+        user = self._make_user(interested_in=["Alien"])
+        tags = get_tags_for_user(user)
+        self.assertNotIn("Alien", tags)
+        self.assertNotIn("Interested Alien", tags)
+
+    def test_session_tag_from_known_slug(self):
+        user = self._make_user()
+        session = SessionFactory.create(slug="2024-session-1")
+        SessionMembershipFactory.create(
+            user=user, session=session, role=constants.DJANGONAUT, accepted=True
+        )
+        self.assertIn("Session 1", get_tags_for_user(user))
+
+    def test_session_tag_all_known_slugs(self):
+        user = self._make_user()
+        for slug, expected_tag in SESSION_SLUG_TO_TAG.items():
+            session = SessionFactory.create(slug=slug)
+            SessionMembershipFactory.create(
+                user=user, session=session, role=constants.ORGANIZER
+            )
+            self.assertIn(expected_tag, get_tags_for_user(user))
+
+    def test_unknown_session_slug_skipped(self):
+        user = self._make_user()
+        session = SessionFactory.create(slug="unknown-session")
+        SessionMembershipFactory.create(
+            user=user, session=session, role=constants.DJANGONAUT, accepted=True
+        )
+        tags = get_tags_for_user(user)
+        self.assertNotIn("Session 0", tags)
+        self.assertNotIn("Session 1", tags)
+
+    def test_role_tag_djangonaut(self):
+        user = self._make_user()
+        SessionMembershipFactory.create(
+            user=user, role=constants.DJANGONAUT, accepted=True
+        )
+        self.assertIn("Djangonaut", get_tags_for_user(user))
+
+    def test_role_tag_navigator(self):
+        user = self._make_user()
+        SessionMembershipFactory.create(user=user, role=constants.NAVIGATOR)
+        self.assertIn("Navigator", get_tags_for_user(user))
+
+    def test_role_tag_captain(self):
+        user = self._make_user()
+        SessionMembershipFactory.create(user=user, role=constants.CAPTAIN)
+        self.assertIn("Captain", get_tags_for_user(user))
+
+    def test_role_tag_organizer(self):
+        user = self._make_user()
+        SessionMembershipFactory.create(user=user, role=constants.ORGANIZER)
+        self.assertIn("Organizer", get_tags_for_user(user))
+
+    def test_role_tags_deduplicated_across_sessions(self):
+        user = self._make_user()
+        SessionMembershipFactory.create(
+            user=user, role=constants.DJANGONAUT, accepted=True
+        )
+        SessionMembershipFactory.create(
+            user=user, role=constants.DJANGONAUT, accepted=True
+        )
+        tags = get_tags_for_user(user)
+        self.assertEqual(tags.count("Djangonaut"), 1)
+
+    def test_in_community_tag_when_role_tag_present(self):
+        user = self._make_user()
+        SessionMembershipFactory.create(
+            user=user, role=constants.DJANGONAUT, accepted=True
+        )
+        self.assertIn("In Community", get_tags_for_user(user))
+
+    def test_in_community_absent_with_no_role_tags(self):
+        user = self._make_user(interested_in=[constants.DJANGONAUT])
+        self.assertNotIn("In Community", get_tags_for_user(user))
+
+    def test_admin_tag_for_superuser(self):
+        user = self._make_user(is_superuser=True)
+        self.assertIn("Admin", get_tags_for_user(user))
+
+    def test_admin_tag_absent_for_regular_user(self):
+        user = self._make_user()
+        self.assertNotIn("Admin", get_tags_for_user(user))
+
+    def test_website_tag_never_returned(self):
+        user = self._make_user()
+        SessionMembershipFactory.create(
+            user=user, role=constants.DJANGONAUT, accepted=True
+        )
+        self.assertNotIn("website", get_tags_for_user(user))
+
+    def test_unaccepted_djangonaut_membership_excluded(self):
+        user = self._make_user()
+        SessionMembershipFactory.create(
+            user=user, role=constants.DJANGONAUT, accepted=False
+        )
+        tags = get_tags_for_user(user)
+        self.assertNotIn("Djangonaut", tags)
+        self.assertNotIn("In Community", tags)
+
+    def test_empty_interested_in_produces_no_interested_tags(self):
+        user = self._make_user(interested_in=[])
+        tags = get_tags_for_user(user)
+        self.assertFalse(any(t.startswith("Interested") for t in tags))
+
+
+# ---------------------------------------------------------------------------
+# ButtondownService._first_sync
+# ---------------------------------------------------------------------------
+
+
+class ButtondownServiceFirstSyncTests(TestCase):
+    def setUp(self):
+        self.user = UserFactory.create()
+        self.user.profile.receiving_newsletter = False
+        self.user.profile.save()
+
+    @override_settings(**BD_SETTINGS)
+    def test_first_sync_links_existing_subscriber(self):
+        existing = {"id": "bd-uuid-existing"}
+        with (
+            patch.object(
+                buttondown_service.client,
+                "get_subscriber_by_email",
+                return_value=existing,
+            ),
+            patch.object(buttondown_service.client, "patch_subscriber") as mock_patch,
+        ):
+            buttondown_service.sync_user(self.user)
+
+        self.assertTrue(ButtondownAccount.objects.filter(user=self.user).exists())
+        account = ButtondownAccount.objects.get(user=self.user)
+        self.assertEqual(account.buttondown_identifier, "bd-uuid-existing")
+
+    @override_settings(**BD_SETTINGS)
+    def test_first_sync_sets_receiving_newsletter_true_when_existing(self):
+        existing = {"id": "bd-uuid-existing"}
+        with (
+            patch.object(
+                buttondown_service.client,
+                "get_subscriber_by_email",
+                return_value=existing,
+            ),
+            patch.object(buttondown_service.client, "patch_subscriber"),
+        ):
+            buttondown_service.sync_user(self.user)
+
+        self.user.profile.refresh_from_db()
+        self.assertTrue(self.user.profile.receiving_newsletter)
+
+    @override_settings(**BD_SETTINGS)
+    def test_first_sync_patches_tags_for_existing_without_website_tag(self):
+        existing = {"id": "bd-uuid-existing"}
+        with (
+            patch.object(
+                buttondown_service.client,
+                "get_subscriber_by_email",
+                return_value=existing,
+            ),
+            patch.object(buttondown_service.client, "patch_subscriber") as mock_patch,
+        ):
+            buttondown_service.sync_user(self.user)
+
+        tags_arg = mock_patch.call_args.args[1]["tags"]
+        self.assertNotIn("website", tags_arg)
+
+    @override_settings(**BD_SETTINGS)
+    def test_first_sync_creates_new_subscriber_when_not_found(self):
+        with (
+            patch.object(
+                buttondown_service.client,
+                "get_subscriber_by_email",
+                return_value=None,
+            ),
+            patch.object(
+                buttondown_service.client,
+                "create_subscriber",
+                return_value={"id": "bd-uuid-new"},
+            ) as mock_create,
+        ):
+            buttondown_service.sync_user(self.user)
+
+        mock_create.assert_called_once()
+        self.assertTrue(ButtondownAccount.objects.filter(user=self.user).exists())
+
+    @override_settings(**BD_SETTINGS)
+    def test_first_sync_new_subscriber_includes_website_tag(self):
+        with (
+            patch.object(
+                buttondown_service.client,
+                "get_subscriber_by_email",
+                return_value=None,
+            ),
+            patch.object(
+                buttondown_service.client,
+                "create_subscriber",
+                return_value={"id": "bd-uuid-new"},
+            ) as mock_create,
+        ):
+            buttondown_service.sync_user(self.user)
+
+        tags_arg = mock_create.call_args.args[1]
+        self.assertIn("website", tags_arg)
+
+    @override_settings(**BD_SETTINGS)
+    def test_first_sync_new_subscriber_does_not_set_receiving_newsletter(self):
+        with (
+            patch.object(
+                buttondown_service.client,
+                "get_subscriber_by_email",
+                return_value=None,
+            ),
+            patch.object(
+                buttondown_service.client,
+                "create_subscriber",
+                return_value={"id": "bd-uuid-new"},
+            ),
+        ):
+            buttondown_service.sync_user(self.user)
+
+        self.user.profile.refresh_from_db()
+        self.assertFalse(self.user.profile.receiving_newsletter)
+
+
+# ---------------------------------------------------------------------------
+# ButtondownService._subsequent_sync
+# ---------------------------------------------------------------------------
+
+
+class ButtondownServiceSubsequentSyncTests(TestCase):
+    def setUp(self):
+        self.user = UserFactory.create()
+        self.user.profile.receiving_newsletter = True
+        self.user.profile.save()
+        self.bd_account = ButtondownAccount.objects.create(
+            user=self.user, buttondown_identifier="bd-uuid-sub"
+        )
+
+    @override_settings(**BD_SETTINGS)
+    def test_subsequent_sync_updates_tags_when_newsletter_true(self):
+        with patch.object(buttondown_service.client, "patch_subscriber") as mock_patch:
+            buttondown_service.sync_user(self.user)
+
+        payload = mock_patch.call_args.args[1]
+        self.assertEqual(payload["subscriber_type"], "regular")
+        self.assertIn("tags", payload)
+
+    @override_settings(**BD_SETTINGS)
+    def test_subsequent_sync_unsubscribes_when_newsletter_false(self):
+        self.user.profile.receiving_newsletter = False
+        self.user.profile.save()
+
+        with patch.object(buttondown_service.client, "patch_subscriber") as mock_patch:
+            buttondown_service.sync_user(self.user)
+
+        payload = mock_patch.call_args.args[1]
+        self.assertEqual(payload, {"subscriber_type": "unsubscribed"})
+
+    @override_settings(**BD_SETTINGS)
+    def test_subsequent_sync_calls_patch_with_correct_id(self):
+        with patch.object(buttondown_service.client, "patch_subscriber") as mock_patch:
+            buttondown_service.sync_user(self.user)
+
+        subscriber_id_arg = mock_patch.call_args.args[0]
+        self.assertEqual(subscriber_id_arg, "bd-uuid-sub")
+
+    @override_settings(**BD_SETTINGS)
+    def test_subsequent_sync_touches_last_updated(self):
+        original_updated = self.bd_account.last_updated
+
+        with patch.object(buttondown_service.client, "patch_subscriber"):
+            buttondown_service.sync_user(self.user)
+
+        self.bd_account.refresh_from_db()
+        self.assertGreaterEqual(self.bd_account.last_updated, original_updated)
+
+
+# ---------------------------------------------------------------------------
+# ButtondownService.remove_user
+# ---------------------------------------------------------------------------
+
+
+class ButtondownServiceRemoveUserTests(TestCase):
+    @override_settings(**BD_SETTINGS)
+    def test_remove_user_calls_delete_subscriber(self):
+        with patch.object(
+            buttondown_service.client, "delete_subscriber"
+        ) as mock_delete:
+            buttondown_service.remove_user("bd-uuid-del")
+
+        mock_delete.assert_called_once_with("bd-uuid-del")
+
+    @override_settings(**BD_SETTINGS)
+    def test_remove_user_for_user_calls_remove_user(self):
+        user = UserFactory.create()
+        ButtondownAccount.objects.create(user=user, buttondown_identifier="bd-uuid-del")
+
+        with patch.object(buttondown_service, "remove_user") as mock_remove:
+            buttondown_service.remove_user_for_user(user)
+
+        mock_remove.assert_called_once_with("bd-uuid-del")
+
+    @override_settings(**BD_SETTINGS)
+    def test_remove_user_for_user_does_nothing_when_no_account(self):
+        user = UserFactory.create()
+
+        with patch.object(buttondown_service, "remove_user") as mock_remove:
+            buttondown_service.remove_user_for_user(user)
+
+        mock_remove.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# sync_user_to_buttondown task
+# ---------------------------------------------------------------------------
+
+
+class SyncUserToButtondownTaskTests(TestCase):
+    @override_settings(BUTTONDOWN_API_KEY="")
+    def test_skips_when_not_configured(self):
+        with patch.object(buttondown_service, "sync_user") as mock_sync:
+            sync_user_to_buttondown.call(user_id=999)
+
+        mock_sync.assert_not_called()
+
+    @override_settings(**BD_SETTINGS)
+    def test_skips_for_missing_user(self):
+        with patch.object(buttondown_service, "sync_user") as mock_sync:
+            sync_user_to_buttondown.call(user_id=999999)
+
+        mock_sync.assert_not_called()
+
+    @override_settings(**BD_SETTINGS)
+    def test_calls_service_sync_user(self):
+        user = UserFactory.create()
+        with patch.object(buttondown_service, "sync_user") as mock_sync:
+            sync_user_to_buttondown.call(user_id=user.pk)
+
+        mock_sync.assert_called_once()
+        self.assertEqual(mock_sync.call_args.args[0].pk, user.pk)
+
+    @override_settings(**BD_SETTINGS)
+    def test_handles_service_exception_without_raising(self):
+        user = UserFactory.create()
+        with patch.object(
+            buttondown_service, "sync_user", side_effect=Exception("API down")
+        ):
+            # Should not raise
+            sync_user_to_buttondown.call(user_id=user.pk)
+
+
+# ---------------------------------------------------------------------------
+# remove_user_from_buttondown task
+# ---------------------------------------------------------------------------
+
+
+class RemoveUserFromButtondownTaskTests(TestCase):
+    @override_settings(BUTTONDOWN_API_KEY="")
+    def test_skips_when_not_configured(self):
+        with patch.object(buttondown_service, "remove_user") as mock_remove:
+            remove_user_from_buttondown.call(buttondown_identifier="bd-uuid")
+
+        mock_remove.assert_not_called()
+
+    @override_settings(**BD_SETTINGS)
+    def test_calls_service_remove_user(self):
+        with patch.object(buttondown_service, "remove_user") as mock_remove:
+            remove_user_from_buttondown.call(buttondown_identifier="bd-uuid")
+
+        mock_remove.assert_called_once_with("bd-uuid")
+
+    @override_settings(**BD_SETTINGS)
+    def test_handles_service_exception_without_raising(self):
+        with patch.object(
+            buttondown_service, "remove_user", side_effect=Exception("API down")
+        ):
+            # Should not raise
+            remove_user_from_buttondown.call(buttondown_identifier="bd-uuid")
+
+
+# ---------------------------------------------------------------------------
+# Signal handlers
+# ---------------------------------------------------------------------------
+
+
+class ButtondownSignalTests(TestCase):
+    """
+    Signal tests use ImmediateBackend (configured in test settings), so
+    enqueued tasks run synchronously. We mock at the service layer to verify
+    the full signal→task→service chain fires correctly.
+    """
+
+    @override_settings(**BD_SETTINGS)
+    def test_profile_save_triggers_sync_when_account_exists(self):
+        user = UserFactory.create()
+        ButtondownAccount.objects.create(
+            user=user, buttondown_identifier="bd-uuid-signal"
+        )
+
+        with patch.object(buttondown_service, "sync_user") as mock_sync:
+            user.profile.bio = "updated"
+            user.profile.save()
+
+        mock_sync.assert_called_once()
+        self.assertEqual(mock_sync.call_args.args[0].pk, user.pk)
+
+    @override_settings(**BD_SETTINGS)
+    def test_profile_save_always_triggers_sync_when_configured(self):
+        user = UserFactory.create()
+        # No ButtondownAccount, receiving_newsletter=False — still syncs
+        with patch.object(buttondown_service, "sync_user") as mock_sync:
+            user.profile.bio = "updated"
+            user.profile.save()
+
+        mock_sync.assert_called_once()
+        self.assertEqual(mock_sync.call_args.args[0].pk, user.pk)
+
+    @override_settings(**BD_SETTINGS)
+    def test_profile_save_triggers_sync_when_opting_in_with_no_account(self):
+        user = UserFactory.create()
+        # No ButtondownAccount but user opts in — trigger first sync
+        with patch.object(buttondown_service, "sync_user") as mock_sync:
+            user.profile.receiving_newsletter = True
+            user.profile.save()
+
+        mock_sync.assert_called_once()
+        self.assertEqual(mock_sync.call_args.args[0].pk, user.pk)
+
+    @override_settings(**BD_SETTINGS)
+    def test_new_signup_triggers_sync(self):
+        # Create via ORM directly so post_save signals fire (factory mutes them)
+        from django.contrib.auth import get_user_model
+
+        User = get_user_model()
+
+        with patch.object(buttondown_service, "sync_user") as mock_sync:
+            User.objects.create_user(username="newuser", email="new@example.com")
+
+        mock_sync.assert_called_once()
+
+    @override_settings(BUTTONDOWN_API_KEY="")
+    def test_profile_save_does_not_sync_when_not_configured(self):
+        user = UserFactory.create()
+        ButtondownAccount.objects.create(
+            user=user, buttondown_identifier="bd-uuid-signal"
+        )
+
+        with patch.object(buttondown_service, "sync_user") as mock_sync:
+            user.profile.bio = "updated"
+            user.profile.save()
+
+        mock_sync.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# sync_buttondown management command
+# ---------------------------------------------------------------------------
+
+
+class SyncButtondownCommandTests(TestCase):
+    """
+    Management command tests use ImmediateBackend, so enqueued tasks run
+    synchronously. We mock at the service layer to verify correct dispatch.
+    """
+
+    @override_settings(**BD_SETTINGS)
+    def test_syncs_active_users(self):
+        from django.core.management import call_command
+
+        active1 = UserFactory.create(is_active=True)
+        active2 = UserFactory.create(is_active=True)
+        UserFactory.create(is_active=False)
+
+        with patch.object(buttondown_service, "sync_user") as mock_sync:
+            call_command("sync_buttondown", stdout=StringIO(), stderr=StringIO())
+
+        synced_pks = {c.args[0].pk for c in mock_sync.call_args_list}
+        self.assertIn(active1.pk, synced_pks)
+        self.assertIn(active2.pk, synced_pks)
+        self.assertEqual(mock_sync.call_count, 2)
+
+    @override_settings(**BD_SETTINGS)
+    def test_dry_run_does_not_sync(self):
+        from django.core.management import call_command
+
+        UserFactory.create(is_active=True)
+
+        with patch.object(buttondown_service, "sync_user") as mock_sync:
+            out = StringIO()
+            call_command("sync_buttondown", dry_run=True, stdout=out, stderr=StringIO())
+
+        mock_sync.assert_not_called()
+        self.assertIn("Dry run", out.getvalue())
+
+    @override_settings(BUTTONDOWN_API_KEY="")
+    def test_aborts_when_not_configured(self):
+        from django.core.management import call_command
+
+        UserFactory.create(is_active=True)
+
+        with patch.object(buttondown_service, "sync_user") as mock_sync:
+            err = StringIO()
+            call_command("sync_buttondown", stdout=StringIO(), stderr=err)
+
+        mock_sync.assert_not_called()
+        self.assertIn("BUTTONDOWN_API_KEY", err.getvalue())

--- a/home/tests/test_buttondown_webhook.py
+++ b/home/tests/test_buttondown_webhook.py
@@ -3,17 +3,18 @@
 import hashlib
 import hmac
 import json
+from unittest.mock import patch
 
 from django.test import TestCase, override_settings
 from django.urls import reverse
 
 from accounts.factories import UserFactory
 from accounts.models import ButtondownAccount, UserProfile
+from home.integrations.buttondown.service import buttondown_service
 from home.integrations.buttondown.webhook import _verify_signature
 
 WEBHOOK_SECRET = "test-webhook-secret"
 WEBHOOK_SETTINGS = {"BUTTONDOWN_WEBHOOK_SECRET": WEBHOOK_SECRET}
-WEBHOOK_URL = "/webhooks/buttondown/"
 
 
 def _make_signature(body: bytes, secret: str = WEBHOOK_SECRET) -> str:
@@ -24,16 +25,11 @@ def _make_signature(body: bytes, secret: str = WEBHOOK_SECRET) -> str:
 def _post(client, payload: dict, secret: str = WEBHOOK_SECRET) -> object:
     body = json.dumps(payload).encode()
     return client.post(
-        WEBHOOK_URL,
+        reverse("buttondown_webhook"),
         data=body,
         content_type="application/json",
         HTTP_X_BUTTONDOWN_SIGNATURE=_make_signature(body, secret),
     )
-
-
-# ---------------------------------------------------------------------------
-# Signature verification
-# ---------------------------------------------------------------------------
 
 
 class VerifySignatureTests(TestCase):
@@ -74,17 +70,12 @@ class VerifySignatureTests(TestCase):
         self.assertFalse(_verify_signature(body, sig))
 
 
-# ---------------------------------------------------------------------------
-# Webhook endpoint
-# ---------------------------------------------------------------------------
-
-
 class WebhookEndpointTests(TestCase):
     @override_settings(**WEBHOOK_SETTINGS)
     def test_rejects_invalid_signature(self):
         body = json.dumps({"event_type": "subscriber.unsubscribed"}).encode()
         response = self.client.post(
-            WEBHOOK_URL,
+            reverse("buttondown_webhook"),
             data=body,
             content_type="application/json",
             headers={"x-buttondown-signature": "sha256=badsig"},
@@ -95,7 +86,7 @@ class WebhookEndpointTests(TestCase):
     def test_rejects_missing_signature(self):
         body = json.dumps({"event_type": "subscriber.unsubscribed"}).encode()
         response = self.client.post(
-            WEBHOOK_URL,
+            reverse("buttondown_webhook"),
             data=body,
             content_type="application/json",
         )
@@ -110,7 +101,7 @@ class WebhookEndpointTests(TestCase):
     def test_rejects_malformed_json(self):
         sig = _make_signature(b"not-json")
         response = self.client.post(
-            WEBHOOK_URL,
+            reverse("buttondown_webhook"),
             data=b"not-json",
             content_type="application/json",
             headers={"x-buttondown-signature": sig},
@@ -123,7 +114,7 @@ class WebhookEndpointTests(TestCase):
         self.assertEqual(response.status_code, 200)
 
     def test_rejects_get_request(self):
-        response = self.client.get(WEBHOOK_URL)
+        response = self.client.get(reverse("buttondown_webhook"))
         self.assertEqual(response.status_code, 405)
 
     @override_settings(**WEBHOOK_SETTINGS)
@@ -132,18 +123,13 @@ class WebhookEndpointTests(TestCase):
         # view is reachable without a CSRF token (no 403 from CSRF middleware).
         body = json.dumps({"event_type": "subscriber.created", "data": {}}).encode()
         response = self.client.post(
-            WEBHOOK_URL,
+            reverse("buttondown_webhook"),
             data=body,
             content_type="application/json",
             headers={"x-buttondown-signature": _make_signature(body)},
             enforce_csrf_checks=True,
         )
         self.assertNotEqual(response.status_code, 403)
-
-
-# ---------------------------------------------------------------------------
-# subscriber.unsubscribed handling
-# ---------------------------------------------------------------------------
 
 
 class SubscriberUnsubscribedTests(TestCase):
@@ -201,9 +187,6 @@ class SubscriberUnsubscribedTests(TestCase):
     @override_settings(**WEBHOOK_SETTINGS)
     def test_does_not_trigger_sync_signal(self):
         """QuerySet.update() bypasses post_save — no sync task is enqueued."""
-        from unittest.mock import patch
-        from home.integrations.buttondown.service import buttondown_service
-
         with patch.object(buttondown_service, "sync_user") as mock_sync:
             _post(self.client, self._unsubscribe_payload())
 

--- a/home/tests/test_buttondown_webhook.py
+++ b/home/tests/test_buttondown_webhook.py
@@ -1,0 +1,210 @@
+"""Tests for the Buttondown webhook handler."""
+
+import hashlib
+import hmac
+import json
+
+from django.test import TestCase, override_settings
+from django.urls import reverse
+
+from accounts.factories import UserFactory
+from accounts.models import ButtondownAccount, UserProfile
+from home.integrations.buttondown.webhook import _verify_signature
+
+WEBHOOK_SECRET = "test-webhook-secret"
+WEBHOOK_SETTINGS = {"BUTTONDOWN_WEBHOOK_SECRET": WEBHOOK_SECRET}
+WEBHOOK_URL = "/webhooks/buttondown/"
+
+
+def _make_signature(body: bytes, secret: str = WEBHOOK_SECRET) -> str:
+    digest = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+    return f"sha256={digest}"
+
+
+def _post(client, payload: dict, secret: str = WEBHOOK_SECRET) -> object:
+    body = json.dumps(payload).encode()
+    return client.post(
+        WEBHOOK_URL,
+        data=body,
+        content_type="application/json",
+        HTTP_X_BUTTONDOWN_SIGNATURE=_make_signature(body, secret),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Signature verification
+# ---------------------------------------------------------------------------
+
+
+class VerifySignatureTests(TestCase):
+    @override_settings(**WEBHOOK_SETTINGS)
+    def test_valid_signature_returns_true(self):
+        body = b'{"event_type": "subscriber.unsubscribed"}'
+        sig = _make_signature(body)
+        self.assertTrue(_verify_signature(body, sig))
+
+    @override_settings(**WEBHOOK_SETTINGS)
+    def test_wrong_secret_returns_false(self):
+        body = b'{"event_type": "subscriber.unsubscribed"}'
+        sig = _make_signature(body, secret="wrong-secret")
+        self.assertFalse(_verify_signature(body, sig))
+
+    @override_settings(**WEBHOOK_SETTINGS)
+    def test_tampered_body_returns_false(self):
+        body = b'{"event_type": "subscriber.unsubscribed"}'
+        sig = _make_signature(body)
+        self.assertFalse(_verify_signature(b'{"event_type": "other"}', sig))
+
+    @override_settings(**WEBHOOK_SETTINGS)
+    def test_missing_sha256_prefix_returns_false(self):
+        body = b'{"event_type": "test"}'
+        digest = hmac.new(WEBHOOK_SECRET.encode(), body, hashlib.sha256).hexdigest()
+        self.assertFalse(_verify_signature(body, digest))  # no "sha256=" prefix
+
+    @override_settings(BUTTONDOWN_WEBHOOK_SECRET="")
+    def test_unconfigured_secret_returns_false(self):
+        body = b'{"event_type": "test"}'
+        sig = _make_signature(body)
+        self.assertFalse(_verify_signature(body, sig))
+
+    @override_settings(BUTTONDOWN_WEBHOOK_SECRET=None)
+    def test_none_secret_returns_false(self):
+        body = b'{"event_type": "test"}'
+        sig = _make_signature(body)
+        self.assertFalse(_verify_signature(body, sig))
+
+
+# ---------------------------------------------------------------------------
+# Webhook endpoint
+# ---------------------------------------------------------------------------
+
+
+class WebhookEndpointTests(TestCase):
+    @override_settings(**WEBHOOK_SETTINGS)
+    def test_rejects_invalid_signature(self):
+        body = json.dumps({"event_type": "subscriber.unsubscribed"}).encode()
+        response = self.client.post(
+            WEBHOOK_URL,
+            data=body,
+            content_type="application/json",
+            headers={"x-buttondown-signature": "sha256=badsig"},
+        )
+        self.assertEqual(response.status_code, 403)
+
+    @override_settings(**WEBHOOK_SETTINGS)
+    def test_rejects_missing_signature(self):
+        body = json.dumps({"event_type": "subscriber.unsubscribed"}).encode()
+        response = self.client.post(
+            WEBHOOK_URL,
+            data=body,
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 403)
+
+    @override_settings(BUTTONDOWN_WEBHOOK_SECRET="")
+    def test_rejects_when_secret_not_configured(self):
+        response = _post(self.client, {"event_type": "subscriber.unsubscribed"})
+        self.assertEqual(response.status_code, 403)
+
+    @override_settings(**WEBHOOK_SETTINGS)
+    def test_rejects_malformed_json(self):
+        sig = _make_signature(b"not-json")
+        response = self.client.post(
+            WEBHOOK_URL,
+            data=b"not-json",
+            content_type="application/json",
+            headers={"x-buttondown-signature": sig},
+        )
+        self.assertEqual(response.status_code, 400)
+
+    @override_settings(**WEBHOOK_SETTINGS)
+    def test_returns_200_for_unknown_event_type(self):
+        response = _post(self.client, {"event_type": "subscriber.created", "data": {}})
+        self.assertEqual(response.status_code, 200)
+
+    def test_rejects_get_request(self):
+        response = self.client.get(WEBHOOK_URL)
+        self.assertEqual(response.status_code, 405)
+
+    @override_settings(**WEBHOOK_SETTINGS)
+    def test_csrf_exempt(self):
+        # Django test client doesn't enforce CSRF by default, but we verify the
+        # view is reachable without a CSRF token (no 403 from CSRF middleware).
+        body = json.dumps({"event_type": "subscriber.created", "data": {}}).encode()
+        response = self.client.post(
+            WEBHOOK_URL,
+            data=body,
+            content_type="application/json",
+            headers={"x-buttondown-signature": _make_signature(body)},
+            enforce_csrf_checks=True,
+        )
+        self.assertNotEqual(response.status_code, 403)
+
+
+# ---------------------------------------------------------------------------
+# subscriber.unsubscribed handling
+# ---------------------------------------------------------------------------
+
+
+class SubscriberUnsubscribedTests(TestCase):
+    def setUp(self):
+        self.user = UserFactory.create()
+        self.user.profile.receiving_newsletter = True
+        self.user.profile.save()
+        self.bd_account = ButtondownAccount.objects.create(
+            user=self.user, buttondown_identifier="bd-uuid-webhook"
+        )
+
+    def _unsubscribe_payload(self, subscriber_id: str = "bd-uuid-webhook") -> dict:
+        return {
+            "event_type": "subscriber.unsubscribed",
+            "data": {"subscriber": subscriber_id},
+        }
+
+    @override_settings(**WEBHOOK_SETTINGS)
+    def test_sets_receiving_newsletter_false(self):
+        response = _post(self.client, self._unsubscribe_payload())
+
+        self.assertEqual(response.status_code, 200)
+        self.user.profile.refresh_from_db()
+        self.assertFalse(self.user.profile.receiving_newsletter)
+
+    @override_settings(**WEBHOOK_SETTINGS)
+    def test_unknown_subscriber_id_returns_200(self):
+        response = _post(self.client, self._unsubscribe_payload("unknown-uuid"))
+
+        self.assertEqual(response.status_code, 200)
+        # Existing user unaffected
+        self.user.profile.refresh_from_db()
+        self.assertTrue(self.user.profile.receiving_newsletter)
+
+    @override_settings(**WEBHOOK_SETTINGS)
+    def test_already_unsubscribed_is_no_op(self):
+        self.user.profile.receiving_newsletter = False
+        self.user.profile.save()
+
+        response = _post(self.client, self._unsubscribe_payload())
+
+        self.assertEqual(response.status_code, 200)
+        self.user.profile.refresh_from_db()
+        self.assertFalse(self.user.profile.receiving_newsletter)
+
+    @override_settings(**WEBHOOK_SETTINGS)
+    def test_missing_subscriber_id_returns_200(self):
+        payload = {"event_type": "subscriber.unsubscribed", "data": {}}
+        response = _post(self.client, payload)
+
+        self.assertEqual(response.status_code, 200)
+        self.user.profile.refresh_from_db()
+        self.assertTrue(self.user.profile.receiving_newsletter)
+
+    @override_settings(**WEBHOOK_SETTINGS)
+    def test_does_not_trigger_sync_signal(self):
+        """QuerySet.update() bypasses post_save — no sync task is enqueued."""
+        from unittest.mock import patch
+        from home.integrations.buttondown.service import buttondown_service
+
+        with patch.object(buttondown_service, "sync_user") as mock_sync:
+            _post(self.client, self._unsubscribe_payload())
+
+        mock_sync.assert_not_called()

--- a/indymeet/settings/base.py
+++ b/indymeet/settings/base.py
@@ -271,6 +271,11 @@ ZOOM_ACCOUNT_ID = os.environ.get("ZOOM_ACCOUNT_ID")
 ZOOM_CLIENT_ID = os.environ.get("ZOOM_CLIENT_ID")
 ZOOM_CLIENT_SECRET = os.environ.get("ZOOM_CLIENT_SECRET")
 
+# Buttondown newsletter integration.
+# Set to enable; leave unset to disable.
+BUTTONDOWN_API_KEY = os.environ.get("BUTTONDOWN_API_KEY")
+BUTTONDOWN_WEBHOOK_SECRET = os.environ.get("BUTTONDOWN_WEBHOOK_SECRET")
+
 ######################
 # Application settings
 ######################

--- a/indymeet/urls.py
+++ b/indymeet/urls.py
@@ -8,8 +8,11 @@ from wagtail import urls as wagtail_urls
 from wagtail.admin import urls as wagtailadmin_urls
 from wagtail.documents import urls as wagtaildocs_urls
 
+from home.integrations.buttondown.webhook import buttondown_webhook
+
 urlpatterns = [
     path("django-admin/", admin.site.urls),
+    path("webhooks/buttondown/", buttondown_webhook, name="buttondown_webhook"),
     path("admin/", include(wagtailadmin_urls)),
     path("documents/", include(wagtaildocs_urls)),
     path("accounts/", include("accounts.urls"), name="accounts"),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ test = [
     "factory_boy",
     "unittest_parametrize",
     "faker",
+    "responses>=0.26.0",
 ]
 dev = [
     "pre-commit",

--- a/uv.lock
+++ b/uv.lock
@@ -558,6 +558,7 @@ test = [
     { name = "pytest-django" },
     { name = "pytest-mock" },
     { name = "pytest-playwright" },
+    { name = "responses" },
     { name = "unittest-parametrize" },
 ]
 
@@ -594,6 +595,7 @@ requires-dist = [
     { name = "pytest-playwright", marker = "extra == 'test'" },
     { name = "python-dotenv" },
     { name = "requests", specifier = ">=2.33.1" },
+    { name = "responses", marker = "extra == 'test'", specifier = ">=0.26.0" },
     { name = "sentry-sdk", extras = ["django"] },
     { name = "six" },
     { name = "supervisor" },
@@ -1334,6 +1336,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5f/a4/98b9c7c6428a668bf7e42ebb7c79d576a1c3c1e3ae2d47e674b468388871/requests-2.33.1.tar.gz", hash = "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517", size = 134120, upload-time = "2026-03-30T16:09:15.531Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl", hash = "sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a", size = 64947, upload-time = "2026-03-30T16:09:13.83Z" },
+]
+
+[[package]]
+name = "responses"
+version = "0.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9f/b4/b7e040379838cc71bf5aabdb26998dfbe5ee73904c92c1c161faf5de8866/responses-0.26.0.tar.gz", hash = "sha256:c7f6923e6343ef3682816ba421c006626777893cb0d5e1434f674b649bac9eb4", size = 81303, upload-time = "2026-02-19T14:38:05.574Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/04/7f73d05b556da048923e31a0cc878f03be7c5425ed1f268082255c75d872/responses-0.26.0-py3-none-any.whl", hash = "sha256:03ec4409088cd5c66b71ecbbbd27fe2c58ddfad801c66203457b3e6a04868c37", size = 35099, upload-time = "2026-02-19T14:38:03.847Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This includes the ability to sync all users initially, and then on every save. It adds a new model called ButtondownAccount with a 1:1 to CustomUser. If a user deletes their account, we should remove them from our newsletter. If a user changes their receiving_newsletter property, that should sync to buttondown.

Closes #736