### PR TITLE
Support caching and cache-busting for Wagtail pages.

### DIFF
--- a/docs/integrations/cloudflare.md
+++ b/docs/integrations/cloudflare.md
@@ -1,0 +1,33 @@
+# Cloudflare Integration
+
+## Overview
+
+The platform uses Wagtail's built-in frontend cache purging to automatically invalidate Cloudflare's CDN cache when pages are published or deleted. No additional Python packages are required.
+
+Reference: https://docs.wagtail.org/en/latest/reference/contrib/frontendcache.html#cloudflare
+
+## Configuration
+
+Two environment variables must be set in production:
+
+| Variable | Description |
+|---|---|
+| `CLOUDFLARE_ZONE_ID` | The zone ID for the domain, found in the Cloudflare dashboard under **Overview** |
+| `CLOUDFLARE_BEARER_TOKEN` | A Cloudflare API token scoped to **Zone › Cache Purge** |
+
+If either variable is absent, cache purging is silently disabled — there is no error.
+
+## Creating the API Token
+
+1. In the Cloudflare dashboard, go to **My Profile › API Tokens**.
+2. Click **Create Token** and use the **Edit zone** template, or create a custom token with a single permission: **Zone › Cache Purge › Purge**.
+3. Scope the token to the relevant zone (djangonaut.space).
+4. Copy the generated token and set it as `CLOUDFLARE_BEARER_TOKEN`.
+
+## Deployment
+
+Set the variables in Dokku:
+
+```bash
+dokku config:set <app> CLOUDFLARE_ZONE_ID=... CLOUDFLARE_BEARER_TOKEN=...
+```

--- a/home/models/blog.py
+++ b/home/models/blog.py
@@ -1,22 +1,15 @@
 from django.db import models
-from django.utils.translation import gettext_lazy as _
+from django.utils.cache import patch_cache_control
 from modelcluster.contrib.taggit import ClusterTaggableManager
 from modelcluster.fields import ParentalKey
 from taggit.models import TaggedItemBase
-from wagtail import blocks
 from wagtail.admin.panels import FieldPanel
-from wagtail.admin.panels import InlinePanel
 from wagtail.admin.panels import MultiFieldPanel
-from wagtail.admin.panels import PageChooserPanel
-from wagtail.contrib.table_block.blocks import TableBlock
 from wagtail.fields import RichTextField
 from wagtail.fields import StreamField
-from wagtail.images.blocks import ImageChooserBlock
 from wagtail.models import Page
 
-from home import blocks as blog_blocks
 from home.blocks import BaseStreamBlock
-from home.models.event import Event
 from home.models.testimonial import Testimonial
 
 # BLOG PUPUT IMPORTS
@@ -27,23 +20,20 @@ class HomePage(Page):
 
     def get_context(self, request):
         context = super().get_context(request)
-        events = Event.objects.visible()
-        past_events = events.past()
-        future_events = events.upcoming()
-        show_rsvp = False
-        if request.user.is_authenticated and request.user.profile.accepted_coc:
-            show_rsvp = True
-        context["past_events"] = past_events[:6]
-        context["future_events"] = future_events[:6]
-        context["show_rsvp"] = show_rsvp
-
         context["testimonials"] = (
             Testimonial.objects.published()
             .select_related("author", "session")
             .order_by("?")[:6]  # random order
         )
-
         return context
+
+    def serve(self, request, *args, **kwargs):
+        response = super().serve(request, *args, **kwargs)
+        if request.user.is_authenticated:
+            patch_cache_control(response, private=True)
+        else:
+            patch_cache_control(response, public=True, max_age=3600)
+        return response
 
 
 class GeneralTag(TaggedItemBase):
@@ -78,3 +68,11 @@ class GeneralPage(Page):
         FieldPanel("body"),
         FieldPanel("content"),
     ]
+
+    def serve(self, request, *args, **kwargs):
+        response = super().serve(request, *args, **kwargs)
+        if request.user.is_authenticated:
+            patch_cache_control(response, private=True)
+        else:
+            patch_cache_control(response, public=True, max_age=3600)
+        return response

--- a/indymeet/settings/base.py
+++ b/indymeet/settings/base.py
@@ -33,6 +33,7 @@ INSTALLED_APPS = [
     "anymail",
     "django_recaptcha",
     "wagtail.contrib.forms",
+    "wagtail.contrib.frontend_cache",
     "wagtail.contrib.redirects",
     "wagtail.contrib.table_block",
     "wagtail.embeds",

--- a/indymeet/settings/production.py
+++ b/indymeet/settings/production.py
@@ -49,5 +49,16 @@ sentry_sdk.init(
 
 BASE_URL = os.getenv("BASE_URL", "https://djangonaut.space")
 
+CLOUDFLARE_BEARER_TOKEN = os.getenv("CLOUDFLARE_BEARER_TOKEN")
+CLOUDFLARE_ZONE_ID = os.getenv("CLOUDFLARE_ZONE_ID")
+if CLOUDFLARE_BEARER_TOKEN and CLOUDFLARE_ZONE_ID:
+    WAGTAILFRONTENDCACHE = {
+        "cloudflare": {
+            "BACKEND": "wagtail.contrib.frontend_cache.backends.CloudflareBackend",
+            "BEARER_TOKEN": CLOUDFLARE_BEARER_TOKEN,
+            "ZONEID": CLOUDFLARE_ZONE_ID,
+        },
+    }
+
 RECAPTCHA_PUBLIC_KEY = os.getenv("RECAPTCHA_PUBLIC_KEY")
 RECAPTCHA_PRIVATE_KEY = os.getenv("RECAPTCHA_PRIVATE_KEY")


### PR DESCRIPTION
For production we need to run:

```bash
dokku config:set djangonaut-space CLOUDFLARE_ZONE_ID=... CLOUDFLARE_BEARER_TOKEN=...
```

The cache status can be confirmed with:
```
curl -sI https://djangonaut.space | grep -i cf-cache-status
```