### PR TITLE
Support buttondown's raw uuids in webhooks.

### DIFF
--- a/docs/integrations/buttondown.md
+++ b/docs/integrations/buttondown.md
@@ -31,6 +31,15 @@ To set it up:
 3. Enable the **subscriber.unsubscribed** event.
 4. Copy the generated webhook secret.
 
+### Subscriber ID Formats
+
+Buttondown subscriber IDs come in two formats depending on the API version:
+
+- **Prefixed format:** `sub_<crockford-base32-encoded-uuid>` (e.g. `sub_5anaxvqk6cvqeyxvqzzynanexv`)
+- **Raw UUID format:** `aaaabbbb-cccc-dddd-eeee-ffffaaaabbbb`
+
+The webhook handler transparently normalizes both formats to a UUID before looking up the user.
+
 | Variable | Description |
 |---|---|
 | `BUTTONDOWN_WEBHOOK_SECRET` | Signing secret used to verify incoming webhook requests |

--- a/home/integrations/buttondown/id_translation.py
+++ b/home/integrations/buttondown/id_translation.py
@@ -1,0 +1,33 @@
+import uuid
+
+# Crockford base32 omits i, l, o, u to avoid visual ambiguity
+# https://www.crockford.com/base32.html
+CROCKFORD = "0123456789abcdefghjkmnpqrstvwxyz"
+
+
+def _crockford_decode(s: str) -> int:
+    n = 0
+    for c in s.lower():
+        n = n * 32 + CROCKFORD.index(c)
+    return n
+
+
+def _crockford_encode(n: int, length: int = 26) -> str:
+    res = ""
+    while n:
+        res = CROCKFORD[n % 32] + res
+        n //= 32
+    return res.zfill(length)
+
+
+def sub_to_uuid(sub_id: str) -> str:
+    """Convert e.g. 'sub_5anaxvqk6cvqeyxvqzzynanexv' → 'aaaabbbb-cccc-dddd-eeee-ffffaaaabbbb'"""
+    prefix, encoded = sub_id.split("_", 1)
+    n = _crockford_decode(encoded)
+    return str(uuid.UUID(bytes=n.to_bytes(16, "big")))
+
+
+def uuid_to_sub(uuid_str: str) -> str:
+    """Convert e.g. 'aaaabbbb-cccc-dddd-eeee-ffffaaaabbbb' → 'sub_5anaxvqk6cvqeyxvqzzynanexv'"""
+    n = int(uuid.UUID(uuid_str).hex, 16)
+    return f"sub_{_crockford_encode(n)}"

--- a/home/integrations/buttondown/webhook.py
+++ b/home/integrations/buttondown/webhook.py
@@ -14,6 +14,7 @@ from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
 
 from accounts.models import ButtondownAccount, UserProfile
+from home.integrations.buttondown import id_translation
 
 logger = logging.getLogger(__name__)
 
@@ -48,6 +49,11 @@ def _handle_unsubscribed(payload: dict) -> None:
     if not subscriber_id:
         logger.warning("subscriber.unsubscribed webhook missing subscriber ID")
         return
+
+    # It's possible buttondown is sending the full uuid4 version of the id
+    # so we need to translate it back into the sub_<encoded> id we store.
+    if not subscriber_id.startswith("sub_") and "-" in subscriber_id:
+        subscriber_id = id_translation.uuid_to_sub(subscriber_id)
 
     try:
         bd_account = ButtondownAccount.objects.get(buttondown_identifier=subscriber_id)
@@ -89,8 +95,6 @@ def buttondown_webhook(request: HttpRequest) -> HttpResponse:
         payload = json.loads(request.body)
     except json.JSONDecodeError:
         return HttpResponseBadRequest("Invalid JSON")
-
-    print("Received payload: %s", payload)
 
     event_type = payload.get("event_type", "")
 

--- a/home/tests/test_buttondown_webhook.py
+++ b/home/tests/test_buttondown_webhook.py
@@ -10,6 +10,7 @@ from django.urls import reverse
 
 from accounts.factories import UserFactory
 from accounts.models import ButtondownAccount, UserProfile
+from home.integrations.buttondown import id_translation
 from home.integrations.buttondown.service import buttondown_service
 from home.integrations.buttondown.webhook import _verify_signature
 
@@ -138,10 +139,10 @@ class SubscriberUnsubscribedTests(TestCase):
         self.user.profile.receiving_newsletter = True
         self.user.profile.save()
         self.bd_account = ButtondownAccount.objects.create(
-            user=self.user, buttondown_identifier="bd-uuid-webhook"
+            user=self.user, buttondown_identifier="bduuidwebhook"
         )
 
-    def _unsubscribe_payload(self, subscriber_id: str = "bd-uuid-webhook") -> dict:
+    def _unsubscribe_payload(self, subscriber_id: str = "bduuidwebhook") -> dict:
         return {
             "event_type": "subscriber.unsubscribed",
             "data": {"subscriber": subscriber_id},
@@ -157,10 +158,19 @@ class SubscriberUnsubscribedTests(TestCase):
 
     @override_settings(**WEBHOOK_SETTINGS)
     def test_unknown_subscriber_id_returns_200(self):
-        response = _post(self.client, self._unsubscribe_payload("unknown-uuid"))
+        response = _post(self.client, self._unsubscribe_payload("unknownsubid"))
 
         self.assertEqual(response.status_code, 200)
         # Existing user unaffected
+        self.user.profile.refresh_from_db()
+        self.assertTrue(self.user.profile.receiving_newsletter)
+
+    @override_settings(**WEBHOOK_SETTINGS)
+    def test_unknown_uuid_subscriber_id_returns_200(self):
+        unknown_uuid = "00000000-0000-0000-0000-000000000001"
+        response = _post(self.client, self._unsubscribe_payload(unknown_uuid))
+
+        self.assertEqual(response.status_code, 200)
         self.user.profile.refresh_from_db()
         self.assertTrue(self.user.profile.receiving_newsletter)
 
@@ -191,3 +201,40 @@ class SubscriberUnsubscribedTests(TestCase):
             _post(self.client, self._unsubscribe_payload())
 
         mock_sync.assert_not_called()
+
+    @override_settings(**WEBHOOK_SETTINGS)
+    def test_uuid_subscriber_id_is_translated_to_sub(self):
+        """
+        Buttondown may send the full UUID form; it should be translated
+        to sub_ before lookup.
+        """
+        known_sub = "sub_43cr6b9qxz9zbr9hes7d36d3zp"
+        known_uuid = "83660cb4-dfbf-4fd7-84c5-d93b46668ff6"
+
+        self.bd_account.buttondown_identifier = known_sub
+        self.bd_account.save()
+
+        response = _post(self.client, self._unsubscribe_payload(known_uuid))
+
+        self.assertEqual(response.status_code, 200)
+        self.user.profile.refresh_from_db()
+        self.assertFalse(self.user.profile.receiving_newsletter)
+
+
+class IdTranslationTests(TestCase):
+    KNOWN_SUB = "sub_5anaxvqk6cvqeyxvqzzynanexv"
+    KNOWN_UUID = "aaaabbbb-cccc-dddd-eeee-ffffaaaabbbb"
+
+    def test_sub_to_uuid_known_value(self):
+        self.assertEqual(id_translation.sub_to_uuid(self.KNOWN_SUB), self.KNOWN_UUID)
+
+    def test_uuid_to_sub_known_value(self):
+        self.assertEqual(id_translation.uuid_to_sub(self.KNOWN_UUID), self.KNOWN_SUB)
+
+    def test_sub_to_uuid_round_trip(self):
+        result = id_translation.uuid_to_sub(id_translation.sub_to_uuid(self.KNOWN_SUB))
+        self.assertEqual(result, self.KNOWN_SUB)
+
+    def test_uuid_to_sub_round_trip(self):
+        result = id_translation.sub_to_uuid(id_translation.uuid_to_sub(self.KNOWN_UUID))
+        self.assertEqual(result, self.KNOWN_UUID)


### PR DESCRIPTION
Buttondown continues to send the uuid version of ids in their webhook, while we store the encoded version. This checks if we need to encode it before searching for the user.