### PR TITLE
Update blog post stats, sources, and role name capitalization

### DIFF
--- a/home/templates/home/reports/launching_contributors.html
+++ b/home/templates/home/reports/launching_contributors.html
@@ -114,13 +114,13 @@
     <section>
       <h2>The software the world runs on is built by a <span>narrow slice</span> of the world.</h2>
 
-      <p>95% of open source contributors identify as men.<sup><a href="#fn1">1</a></sup> Only 18% identify as ethnic minorities in their country of birth.<sup><a href="#fn2">2</a></sup> Most pull requests come from developers in the US, UK, and Germany.<sup><a href="#fn3">3</a></sup></p>
+      <p>95% of open source contributors identify as men.<sup><a href="#fn1">1</a></sup> Most pull requests come from developers in the US, UK, and Germany.<sup><a href="#fn2">2</a></sup></p>
 
       <div class="comparison">
         <div class="comparison-card">
-          <span class="num problem">~9%</span>
-          <span class="label">of open source contributors<br>are <strong>gender minorities</strong></span>
-          <span class="source">LF &amp; Harvard FOSS Survey, 2020</span>
+          <span class="num problem">8%</span>
+          <span class="label">of Python open source contributors<br>are <strong>women or gender minorities</strong></span>
+          <span class="source">Python Developers Survey 2024, JetBrains/PSF</span>
         </div>
         <div class="comparison-card">
           <span class="num solution">48%</span>
@@ -129,7 +129,7 @@
         </div>
       </div>
 
-      <p>This isn't just an equity problem. It's an engineering problem. Diverse teams solve complex tasks 60% faster.<sup><a href="#fn4">4</a></sup> Diverse open source repositories produce superior code quality.<sup><a href="#fn5">5</a></sup> When female contributors' gender is identifiable, their code acceptance rate drops 12%, even though their code was accepted at <em>higher</em> rates when gender was hidden.<sup><a href="#fn6">6</a></sup></p>
+      <p>This isn't just an equity problem. It's an engineering problem. Diverse teams solve complex tasks 60% faster.<sup><a href="#fn3">3</a></sup> Diverse open source repositories produce superior code quality.<sup><a href="#fn4">4</a></sup> When female contributors' gender is identifiable, their code acceptance rate drops 12%, even though their code was accepted at <em>higher</em> rates when gender was hidden.<sup><a href="#fn5">5</a></sup></p>
 
       <p>Open source has a diversity problem. And it's making the software worse.</p>
     </section>
@@ -149,7 +149,7 @@
         <div class="video-label"><strong>Rachell Calhoun</strong>, Co-founder</div>
       </div>
 
-      <p>And we kept hearing that people wanted to contribute but didn't know how. They'd open the issue tracker, feel overwhelmed, and close the tab. Or they'd submit a pull request and never hear back. We saw that gap between wanting to contribute and actually getting in, and we saw the bridge it needed. So in 2023, a small group of volunteers built Djangonaut Space: an 8-week group mentorship program that pairs people who want to contribute to open source with people who already do. Each team of three djangonauts gets a navigator (technical mentor) and a captain (community mentor).</p>
+      <p>And we kept hearing that people wanted to contribute but didn't know how. They'd open the issue tracker, feel overwhelmed, and close the tab. Or they'd submit a pull request and never hear back. We saw that gap between wanting to contribute and actually getting in, and we saw the bridge it needed. So in 2023, a small group of volunteers built Djangonaut Space: an 8-week group mentorship program that pairs people who want to contribute to open source with people who already do. Each team of three Djangonauts gets a Navigator (technical mentor) and a Captain (community mentor).</p>
 
       <div class="video-grid">
         <div class="video-card">
@@ -157,8 +157,8 @@
           <div class="video-label"><strong>Tim Schilling</strong>, Co-founder</div>
         </div>
         <div class="video-card">
-          <img src="{% static 'images/reports/launching_contributors/2026/lillian_every_role.jpg' %}" alt="Lilian Tran: Session 1 djangonaut who went on to hold every role in the program.">
-          <div class="video-label"><strong>Lilian Tran</strong>, S1 djangonaut, held every role</div>
+          <img src="{% static 'images/reports/launching_contributors/2026/lillian_every_role.jpg' %}" alt="Lilian Tran: Session 1 Djangonaut who went on to hold every role in the program.">
+          <div class="video-label"><strong>Lilian Tran</strong>, S1 Djangonaut, held every role</div>
         </div>
       </div>
 
@@ -191,7 +191,7 @@
           <tr><td><strong>Total</strong></td><td><strong>680+</strong></td><td><strong>104</strong></td><td><strong>~15%</strong></td></tr>
         </tbody>
       </table>
-      <p><small>All counts from program tracking data.<sup><a href="#fn7">7</a></sup></small></p>
+      <p><small>All counts from program tracking data.<sup><a href="#fn6">6</a></sup></small></p>
 
       <div class="stat-row">
         <div class="stat-card"><span class="num">5 yrs</span><span class="label">median programming experience</span></div>
@@ -199,9 +199,9 @@
         <div class="stat-card"><span class="num">15%</span><span class="label">acceptance rate</span></div>
       </div>
 
-      <p>The typical applicant has a median of 5 years of programming experience.<sup><a href="#fn8">8</a></sup> These aren't beginners. They're working developers who use Django every day but haven't found their way into contributing. Because open source contribution is hard to do alone.</p>
+      <p>The typical applicant has a median of 5 years of programming experience.<sup><a href="#fn7">7</a></sup> These aren't beginners. They're working developers who use Django every day but haven't found their way into contributing. Because open source contribution is hard to do alone.</p>
 
-      <p>And here's what surprised us: the people we accept actually have slightly <em>less</em> experience than those we don't (4.9 years vs 5.9 years on average).<sup><a href="#fn8">8</a></sup> We don't select for the longest resume. We select for resilience, motivation, and wanting to give back.</p>
+      <p>And here's what surprised us: the people we accept actually have slightly <em>less</em> experience than those we don't (4.9 years vs 5.9 years on average).<sup><a href="#fn7">7</a></sup> We don't select for the longest resume. We select for resilience, motivation, and wanting to give back.</p>
     </section>
 
     <div class="divider"></div>
@@ -212,25 +212,25 @@
     <section>
       <h2>Active Inclusion <span>by Design</span></h2>
 
-      <p><strong>82%</strong> of our accepted djangonauts come from underrepresented backgrounds, compared to 18% in open source overall.<sup><a href="#fn2">2</a></sup><sup><a href="#fn7">7</a></sup></p>
+      <p><strong>82%</strong> of our accepted Djangonauts come from underrepresented backgrounds.<sup><a href="#fn6">6</a></sup></p>
 
-      <p>This didn't happen by accident. Across every session, gender minorities have been accepted at 3 to 10 times their representation in the applicant pool.<sup><a href="#fn10">10</a></sup> For example, in Session 1 gender minorities made up 17% of applicants but 71% of those accepted. In Session 6, 23% of the pool and 56% of those accepted.</p>
-
-      <div class="chart-container">
-        <img src="{% static 'images/reports/launching_contributors/2026/chart_gender_accepted_only_light.png' %}" alt="Gender minority percentage per session among accepted djangonauts">
-        <div class="chart-caption">Gender minority representation among accepted djangonauts, by session.</div>
-      </div>
-
-      <p>Representation matters. When people see others who look like them or share their background contributing to a project, it stops feeling like something other people do and starts feeling possible. And we're seeing that play out: the applicant pool itself is growing more diverse on its own. Underrepresented applicants went from 68% of the pool in Session 1 to 86% in Session 6, an 18 percentage point increase over six sessions.<sup><a href="#fn10">10</a></sup> Diversity attracts diversity.</p>
-
-      <h3>Where our djangonauts come from</h3>
+      <p>This didn't happen by accident. Across every session, gender minorities have been accepted at 3 to 10 times their representation in the applicant pool.<sup><a href="#fn9">9</a></sup> For example, in Session 1 gender minorities made up 17% of applicants but 71% of those accepted. In Session 6, 23% of the pool and 56% of those accepted.</p>
 
       <div class="chart-container">
-        <img src="{% static 'images/reports/launching_contributors/2026/geographic_combined_accepted_s4s6_light.png' %}" alt="Where our accepted djangonauts come from: Africa 42%, Global North 38%, Latin America 13%, South Asia 8%">
-        <div class="chart-caption">Geographic distribution of accepted djangonauts, Sessions 4-6.<sup><a href="#fn7">7</a></sup></div>
+        <img src="{% static 'images/reports/launching_contributors/2026/chart_gender_accepted_only_light.png' %}" alt="Gender minority percentage per session among accepted Djangonauts">
+        <div class="chart-caption">Gender minority representation among accepted Djangonauts, by session.</div>
       </div>
 
-      <p>The top applicant countries: Nigeria, India, Kenya, Ghana, Pakistan, and Egypt.<sup><a href="#fn7">7</a></sup> This is what open source could look like everywhere.</p>
+      <p>Representation matters. When people see others who look like them or share their background contributing to a project, it stops feeling like something other people do and starts feeling possible. And we're seeing that play out: the applicant pool itself is growing more diverse on its own. Underrepresented applicants went from 68% of the pool in Session 1 to 86% in Session 6, an 18 percentage point increase over six sessions.<sup><a href="#fn9">9</a></sup> Diversity attracts diversity.</p>
+
+      <h3>Where our Djangonauts come from</h3>
+
+      <div class="chart-container">
+        <img src="{% static 'images/reports/launching_contributors/2026/geographic_combined_accepted_s4s6_light.png' %}" alt="Where our accepted Djangonauts come from: Africa 42%, Global North 38%, Latin America 13%, South Asia 8%">
+        <div class="chart-caption">Geographic distribution of accepted Djangonauts, Sessions 4-6.<sup><a href="#fn6">6</a></sup></div>
+      </div>
+
+      <p>The top applicant countries: Nigeria, India, Kenya, Ghana, Pakistan, and Egypt.<sup><a href="#fn6">6</a></sup> This is what open source could look like everywhere.</p>
     </section>
 
     <div class="divider"></div>
@@ -247,7 +247,7 @@
         <div class="stat-card"><span class="num">100%</span><span class="label">would recommend the program</span></div>
       </div>
 
-      <p>Before the program, djangonauts rated their confidence contributing to Django at <strong>2.3 out of 5</strong>. After? <strong>4.3</strong>.<sup><a href="#fn12">12</a></sup> That's people going from "I'm not sure I can do this" to "I know I can."</p>
+      <p>Before the program, Djangonauts rated their confidence contributing to Django at <strong>2.3 out of 5</strong>. After? <strong>4.3</strong>.<sup><a href="#fn11">11</a></sup> That's people going from "I'm not sure I can do this" to "I know I can."</p>
 
       <div class="quote-block">
         <p>"I felt as though I wasn't the kind of person who could become a Django contributor. Now I feel like I found a place where I belong."</p>
@@ -256,11 +256,11 @@
         </div>
       </div>
 
-      <p>Our follow-up survey of 24 alumni paints a fuller picture across five dimensions, every one showing dramatic positive movement. After the program, nearly every respondent agreed or strongly agreed that they feel like a member of the Django community, and that they belong in the open source community. Before the program, many had strongly disagreed.<sup><a href="#fn12">12</a></sup></p>
+      <p>Our follow-up survey of 24 alumni paints a fuller picture across five dimensions, every one showing dramatic positive movement. After the program, nearly every respondent agreed or strongly agreed that they feel like a member of the Django community, and that they belong in the open source community. Before the program, many had strongly disagreed.<sup><a href="#fn11">11</a></sup></p>
 
-      <p>From exit surveys: 97% feel more comfortable contributing to Django, 53% said their growth exceeded their own expectations, and 100% would recommend the program.<sup><a href="#fn11">11</a></sup></p>
+      <p>From exit surveys: 97% feel more comfortable contributing to Django, 53% said their growth exceeded their own expectations, and 100% would recommend the program.<sup><a href="#fn10">10</a></sup></p>
 
-      <p>And the impact keeps going after the program ends:<sup><a href="#fn12">12</a></sup></p>
+      <p>And the impact keeps going after the program ends:<sup><a href="#fn11">11</a></sup></p>
 
       <ul>
         <li>88% built confidence making open source contributions</li>
@@ -284,7 +284,7 @@
     <!-- ============================================================ -->
     <section>
       <h2>More Than <span>Code</span></h2>
-      <p class="section-lead">At the end of each session, djangonauts present what they learned in a showcase. What they talk about is rarely about code.</p>
+      <p class="section-lead">At the end of each session, Djangonauts present what they learned in a <a href="https://www.youtube.com/@Djangonautspace/search?query=showcase">showcase</a>. What they talk about is rarely about code.</p>
 
       <div class="video-grid">
         <div class="video-card">
@@ -292,7 +292,7 @@
           <div class="video-label"><strong>Maria</strong>, Session 3</div>
         </div>
         <div class="video-card">
-          <img src="{% static 'images/reports/launching_contributors/2026/collins_changed_that.jpg' %}" alt="Collins: My captain and navigator really changed that for me. They kept reminding me that open source is for everyone.">
+          <img src="{% static 'images/reports/launching_contributors/2026/collins_changed_that.jpg' %}" alt="Collins: My Captain and Navigator really changed that for me. They kept reminding me that open source is for everyone.">
           <div class="video-label"><strong>Collins</strong>, Session 5</div>
         </div>
       </div>
@@ -342,13 +342,13 @@
         Some people were already avid OSS contributors, some people become regular contributors and some don't. Keep in mind, this is only displaying technical participation for members. It does not consider other contributions such as community/conference organizing which are incredibly valuable to the community.
       </p>
       {% include "home/reports/charts/chart_individual_timelines.html" %}
-      <p class="chart-caption" style="text-align:center;">Monthly open source activity for each session's members over time. One panel per session. Solid vertical line = session start date; dotted = session end date.<sup><a href="#fn18">18</a></sup></p>
+      <p class="chart-caption" style="text-align:center;">Monthly open source activity for each session's members over time. One panel per session. Solid vertical line = session start date; dotted = session end date.<sup><a href="#fn16">16</a></sup></p>
 
       {% include "home/reports/charts/chart_monthly_activity.html" %}
-      <p class="chart-caption" style="text-align:center;">Monthly open source activity for each session's members over time. Shaded bands mark each session's program window. Clicking on the series will show/hide the relevant dataset.<sup><a href="#fn18">18</a></sup></p>
+      <p class="chart-caption" style="text-align:center;">Monthly open source activity for each session's members over time. Shaded bands mark each session's program window. Clicking on the series will show/hide the relevant dataset.<sup><a href="#fn16">16</a></sup></p>
 
       {% include "home/reports/charts/chart_heatmap.html" %}
-      <p class="chart-caption" style="text-align:center;">Look for more color to the right of the solid lines to see individuals who had a behavior change due to the session. <br />Every row is a program member; every column is a month. Color intensity uses a log(1+n) scale so a handful of high-volume contributors don't wash out everyone else. A faint blue square still represents real activity. Solid colored lines mark each session's start date; dotted lines mark the end. Orange horizontal lines divide the sessions.<sup><a href="#fn18">18</a></sup></p>
+      <p class="chart-caption" style="text-align:center;">Look for more color to the right of the solid lines to see individuals who had a behavior change due to the session. <br />Every row is a program member; every column is a month. Color intensity uses a log(1+n) scale so a handful of high-volume contributors don't wash out everyone else. A faint blue square still represents real activity. Solid colored lines mark each session's start date; dotted lines mark the end. Orange horizontal lines divide the sessions.<sup><a href="#fn16">16</a></sup></p>
 
       <h3>
         The Behavior Change in Numbers
@@ -358,7 +358,7 @@
       </p>
 
       {% include "home/reports/charts/chart_phase_rates.html" %}
-      <p class="chart-caption" style="text-align:center;">Actions per user per day from before, during, and after the program. Three panels: all participants, the most active 5%, and the remaining 95%. Multipliers show the change relative to each panel's Before rate.<sup><a href="#fn18">18</a></sup></p>
+      <p class="chart-caption" style="text-align:center;">Actions per user per day from before, during, and after the program. Three panels: all participants, the most active 5%, and the remaining 95%. Multipliers show the change relative to each panel's Before rate.<sup><a href="#fn16">16</a></sup></p>
 
       <p>What we found is that, on average, there's a <strong>1.7× increase</strong> over pre-program activity. This is evidence of a behavioral change of participating more in open source software.</p>
 
@@ -366,12 +366,12 @@
 
       {% include "home/reports/charts/chart_group_activity_rate.html" %}
 
-      <p class="chart-caption" style="text-align:center;">Actions per user per day for unaccepted applicants. Three panels: all participants, the most active 5%, and the remaining 95%.<sup><a href="#fn19">19</a></sup></p>
+      <p class="chart-caption" style="text-align:center;">Actions per user per day for unaccepted applicants. Three panels: all participants, the most active 5%, and the remaining 95%.<sup><a href="#fn17">17</a></sup></p>
 
       <p>The behavior change to participate more in open source is driven by successful contributions and momentum. Our Djangonauts have had <strong>157 PRs merged</strong> across all sessions, with even more opened. Below you will see the breakdown of PRs opened per session:</p>
 
       {% include "home/reports/charts/chart_prs.html" %}
-      <p class="chart-caption" style="text-align:center;">Number of Pull Requests opened per session.<sup><a href="#fn18">18</a></sup></p>
+      <p class="chart-caption" style="text-align:center;">Number of Pull Requests opened per session.<sup><a href="#fn16">16</a></sup></p>
 
     </section>
 
@@ -382,11 +382,11 @@
     <!-- ============================================================ -->
     <section>
       <h2>Leaders <span>Emerge</span></h2>
-      <p class="section-lead">The program doesn't end at session close. Djangonauts become captains, navigators, session organizers, DSF board members, conference chairs, and community founders.</p>
+      <p class="section-lead">The program doesn't end at session close. Djangonauts become Captains, Navigators, session organizers, DSF board members, conference chairs, and community founders.</p>
 
       <div class="chart-container">
         <img src="{% static 'images/reports/launching_contributors/2026/chart_pipeline_funnel_light.png' %}" alt="The Pipeline: 104 accepted, 22 returned as volunteers, 35+ in leadership roles.">
-        <div class="chart-caption">21% of djangonauts returned to the program in volunteer roles. 35+ are now in leadership positions across the Django ecosystem.<sup><a href="#fn13">13</a></sup></div>
+        <div class="chart-caption">21% of Djangonauts returned to the program in volunteer roles. 35+ are now in leadership positions across the Django ecosystem.<sup><a href="#fn12">12</a></sup></div>
       </div>
 
       <div class="stat-row">
@@ -397,27 +397,27 @@
       </div>
 
       <ul class="pipeline-list">
-        <li><span class="name">Afi (Abigail Gbadago)</span><span class="journey">S3 djangonaut &rarr; <strong>DSF Vice President</strong>, PSF Fellow, DjangoCon US Program Chair</span></li>
-        <li><span class="name">Lilian Tran</span><span class="journey">S1 djangonaut &rarr; captain &rarr; organizer &rarr; navigator &rarr; admin. Held every role. 4+ conference talks. Django Triage & Review team member.</span></li>
-        <li><span class="name">Keanya Phelps</span><span class="journey">S1 djangonaut &rarr; captain 4x &rarr; <strong>DjangoCon US Chair</strong></span></li>
-        <li><span class="name">Priya Pahwa</span><span class="journey">S1 djangonaut &rarr; organizer &rarr; <strong>DSF Board</strong>, Fundraising WG Lead</span></li>
-        <li><span class="name">Raffaella Suardini</span><span class="journey">S1 djangonaut &rarr; organizer &rarr; <strong>Djangonaut Space admin</strong>, Django Triage & Review team member</span></li>
-        <li><span class="name">Alex Gomez</span><span class="journey">S2 djangonaut &rarr; <strong>PyCon Spain main organizer</strong>, DSF Website WG, Django Girls coach (5+ events)</span></li>
-        <li><span class="name">Moe (Mohammad Alsakhawy)</span><span class="journey">S1 djangonaut &rarr; captain &rarr; <strong>founded first Django meetup in Egypt</strong> (27 attendees, 170+ Discord members)</span></li>
-        <li><span class="name">Farhan Ali Raza</span><span class="journey">S2 djangonaut &rarr; organizer &rarr; <strong>Django core contributor</strong> (brought django-template-partials into Django)</span></li>
-        <li><span class="name">Eliana Rosselli</span><span class="journey">S1 djangonaut &rarr; navigator 2x &rarr; <strong>Django Accessibility Team co-chair</strong>, DSF Member</span></li>
-        <li><span class="name">Rahmat Akintola</span><span class="journey">S2 djangonaut &rarr; captain &rarr; organizer &rarr; <strong>Django Accessibility WG</strong>, Django Girls coach, Program Lead at Everything Open Source</span></li>
+        <li><span class="name">Afi (Abigail Gbadago)</span><span class="journey">S3 Djangonaut &rarr; <strong>DSF Vice President</strong>, PSF Fellow, DjangoCon US Program Chair</span></li>
+        <li><span class="name">Lilian Tran</span><span class="journey">S1 Djangonaut &rarr; Captain &rarr; organizer &rarr; Navigator &rarr; admin. Held every role. 4+ conference talks. Django Triage & Review team member.</span></li>
+        <li><span class="name">Keanya Phelps</span><span class="journey">S1 Djangonaut &rarr; Captain 4x &rarr; <strong>DjangoCon US Chair</strong></span></li>
+        <li><span class="name">Priya Pahwa</span><span class="journey">S1 Djangonaut &rarr; organizer &rarr; <strong>DSF Board</strong>, Fundraising WG Lead</span></li>
+        <li><span class="name">Raffaella Suardini</span><span class="journey">S1 Djangonaut &rarr; organizer &rarr; <strong>Djangonaut Space admin</strong>, Django Triage & Review team member</span></li>
+        <li><span class="name">Alex Gomez</span><span class="journey">S2 Djangonaut &rarr; <strong>PyCon Spain main organizer</strong>, DSF Website WG, Django Girls coach (5+ events)</span></li>
+        <li><span class="name">Moe (Mohammad Alsakhawy)</span><span class="journey">S1 Djangonaut &rarr; Captain &rarr; <strong>founded first Django meetup in Egypt</strong> (27 attendees, 170+ Discord members)</span></li>
+        <li><span class="name">Farhan Ali Raza</span><span class="journey">S2 Djangonaut &rarr; organizer &rarr; <strong>Django core contributor</strong> (brought django-template-partials into Django)</span></li>
+        <li><span class="name">Eliana Rosselli</span><span class="journey">S1 Djangonaut &rarr; Navigator 2x &rarr; <strong>Django Accessibility Team co-chair</strong>, DSF Member</span></li>
+        <li><span class="name">Rahmat Akintola</span><span class="journey">S2 Djangonaut &rarr; Captain &rarr; organizer &rarr; <strong>Django Accessibility WG</strong>, Django Girls coach, Program Lead at Everything Open Source</span></li>
         <li><span class="name">Soyoung Kang</span><span class="journey">Djangonaut &rarr; <strong>PyCon Korea organizer</strong></span></li>
-        <li><span class="name">Annabelle</span><span class="journey">S5 djangonaut &rarr; <strong>PyLadies Zurich organizer</strong></span></li>
+        <li><span class="name">Annabelle</span><span class="journey">S5 Djangonaut &rarr; <strong>PyLadies Zurich organizer</strong></span></li>
       </ul>
 
-      <p>More than eight djangonauts have given talks at conferences including DjangoCon US, DjangoCon Europe, FOSDEM, PyCon Italia, Python Ghana, North Bay Python, Google DevFest Lagos, and PyLadiesCon. Five serve on Django working groups across Accessibility, Fundraising, and the Website Working Group.<sup><a href="#fn13">13</a></sup><sup><a href="#fn14">14</a></sup></p>
+      <p>More than eight Djangonauts have given talks at conferences including DjangoCon US, DjangoCon Europe, FOSDEM, PyCon Italia, Python Ghana, North Bay Python, Google DevFest Lagos, and PyLadiesCon. Five serve on Django working groups across Accessibility, Fundraising, and the Website Working Group.<sup><a href="#fn12">12</a></sup><sup><a href="#fn13">13</a></sup></p>
 
       <div class="caveat">
-        These numbers come from just 24 survey respondents, roughly 23% of all alumni.<sup><a href="#fn12">12</a></sup> The real numbers are almost certainly higher.
+        These numbers come from just 24 survey respondents, roughly 23% of all alumni.<sup><a href="#fn11">11</a></sup> The real numbers are almost certainly higher.
       </div>
 
-      <p>73% of officers say they feel more comfortable in mentoring and leadership positions because of this program.<sup><a href="#fn16">16</a></sup> We're not just producing contributors. We're producing the people who produce contributors.</p>
+      <p>73% of officers say they feel more comfortable in mentoring and leadership positions because of this program.<sup><a href="#fn14">14</a></sup> We're not just producing contributors. We're producing the people who produce contributors.</p>
 
       <div class="video-single">
         <img src="{% static 'images/reports/launching_contributors/2026/hiram_help_others.jpg' %}" alt="Hiram Choi: Someday I hope I can help someone else take their first step.">
@@ -433,11 +433,11 @@
     <section>
       <h2>What a Small <span>Budget</span> Can Do</h2>
 
-      <p>Our total financial aid budget across two and a half years: <strong>$2,275</strong>.<sup><a href="#fn17">17</a></sup></p>
+      <p>Our total financial aid budget across two and a half years: <strong>$2,275</strong>.<sup><a href="#fn15">15</a></sup></p>
 
-      <p>With it, we've supported 13 people to attend conferences around the world. For some, it was their first. The conferences include PyCon Ireland, FOSDEM, PyCon US, DjangoCon Africa, and DjangoDay India.<sup><a href="#fn17">17</a></sup></p>
+      <p>With it, we've supported 13 people to attend conferences around the world. For some, it was their first. The conferences include PyCon Ireland, FOSDEM, PyCon US, DjangoCon Africa, and DjangoDay India.<sup><a href="#fn15">15</a></sup></p>
 
-      <p>Two grants were canceled because recipients couldn't obtain visas, a reminder that access isn't just about money.<sup><a href="#fn17">17</a></sup></p>
+      <p>Two grants were canceled because recipients couldn't obtain visas, a reminder that access isn't just about money.<sup><a href="#fn15">15</a></sup></p>
 
       <p>People who received grants went on to give talks, organize workshops, join the DSF board, and come back to Djangonaut Space as volunteers. That's not a conference ticket. That's a trajectory.</p>
     </section>
@@ -445,7 +445,7 @@
     <section>
       <h2>The Cost of <span>Showing Up</span></h2>
       <p>
-        Djangonaut Space has led to more contributors and community leaders by being intentional and maintaining a positive community. This has required quite an investment. Let’s look at a few more numbers. Over the six sessions, we have had 104 Djangonauts participate who have invested roughly 3,300 hours. Then we have our 52 volunteers across our navigator, captain and organizer roles, who have invested about 2,500 hours.
+        Djangonaut Space has led to more contributors and community leaders by being intentional and maintaining a positive community. This has required quite an investment. Let’s look at a few more numbers. Over the six sessions, we have had 104 Djangonauts participate who have invested roughly 3,300 hours. Then we have our 52 volunteers across our Navigator, Captain and organizer roles, who have invested about 2,500 hours.
       </p>
       <div class="stat-row">
         <div class="stat-card"><span class="num">3,300 hours</span><span class="label">across 104 Djangonauts</span></div>
@@ -467,11 +467,11 @@
     <section>
       <h2>What the Numbers <span>Can't Capture</span></h2>
 
-      <p>During one session showcase, a djangonaut talked about living with a chronic illness that had disconnected her from traditional work and community. She'd struggled to even describe herself anymore. The things she used to love felt like they belonged to a different person. But open source, and this program, gave her a way to contribute at her own pace, find purpose, and help make the web more accessible for people like her.</p>
+      <p>During one session showcase, a Djangonaut talked about living with a chronic illness that had disconnected her from traditional work and community. She'd struggled to even describe herself anymore. The things she used to love felt like they belonged to a different person. But open source, and this program, gave her a way to contribute at her own pace, find purpose, and help make the web more accessible for people like her.</p>
 
       <p>The chat filled with hearts.</p>
 
-      <p>She's not alone. Across every session, djangonauts are finding their place and discovering they belong. Not because someone handed it to them, but because a community made space for them to show up as they are.</p>
+      <p>She's not alone. Across every session, Djangonauts are finding their place and discovering they belong. Not because someone handed it to them, but because a community made space for them to show up as they are.</p>
 
       <div class="video-grid">
         <div class="video-card">
@@ -544,24 +544,22 @@
 
       <ol class="footnotes">
         <li id="fn1"><strong>[1] GitHub Open Source Survey (2017).</strong> 95% of respondents identified as men, 3% as women, 1% as non-binary. <a href="https://opensourcesurvey.org/2017/">opensourcesurvey.org/2017</a></li>
-        <li id="fn2"><strong>[2] GitHub Open Source Survey (2024).</strong> 18% identified as ethnic minorities in their country of birth, up from 13% in 2017. <a href="https://opensourcesurvey.org/2024/">opensourcesurvey.org/2024</a></li>
-        <li id="fn3"><strong>[3] GitHub geographic data.</strong> Most closed pull requests come from developers in the US, UK, and Germany. <a href="https://opensourcesurvey.org/2024/">opensourcesurvey.org/2024</a></li>
-        <li id="fn4"><strong>[4] Harvard Business Review.</strong> Cognitively diverse teams solve complex tasks 60% faster.</li>
-        <li id="fn5"><strong>[5] IEEE, "Diversity and Inclusion in Open Source Software Projects."</strong> Diverse repositories have superior code quality. <a href="https://ieeexplore.ieee.org/abstract/document/8870179">ieeexplore.ieee.org</a></li>
-        <li id="fn6"><strong>[6] GitHub study on gender bias in code review.</strong> Acceptance drops 12% when gender is identifiable. <a href="https://en.wikipedia.org/wiki/Diversity_in_open-source_software">Wikipedia</a></li>
-        <li id="fn7"><strong>[7] Djangonaut Space program tracking data.</strong> Consolidated from application records and accepted participant lists across Pilot + Sessions 1-6. 104 unique accepted djangonauts, 680+ applications, 226 total volunteers, 40+ countries. Geographic data available for Sessions 4-6.</li>
-        <li id="fn8"><strong>[8] Applicant experience analysis.</strong> Extracted from freeform application responses. 202 of ~680 applicants (30%) explicitly mentioned years of experience. Accepted sample: 28 of 99.</li>
-        <li id="fn9"><strong>[9] Linux Foundation &amp; Harvard, 2020 FOSS Contributor Survey.</strong> ~9% gender minorities among open source contributors. <a href="https://www.linuxfoundation.org/resources/publications/foss-contributor-2020">linuxfoundation.org</a></li>
-        <li id="fn10"><strong>[10] Djangonaut Space demographics analysis.</strong> Computed from self-reported underrepresented status and gender minority status collected from applicants.</li>
-        <li id="fn11"><strong>[11] Exit surveys, Sessions 1-5.</strong> 32 responses from djangonauts. 97% feel more comfortable contributing. 53% said growth exceeded expectations.</li>
-        <li id="fn12"><strong>[12] Alumni follow-up survey, 2026.</strong> 24 respondents out of 104 alumni (~23% response rate). Measured post-program contributions, benefits, and before/after confidence across 5 dimensions.</li>
-        <li id="fn13"><strong>[13] Leadership pipeline tracking.</strong> Compiled from program records and alumni survey responses. 22 unique people returning in volunteer roles. Some individuals hold multiple roles.</li>
-        <li id="fn14"><strong>[14] Survey-reported external leadership and conference activity.</strong> Self-reported by 24 alumni survey respondents. 18 of 24 attended conferences or events post-program.</li>
-        <li id="fn15"><strong>[15] Djangonaut Space Session 5 showcase presentations (November 2025).</strong></li>
-        <li id="fn16"><strong>[16] Officer exit surveys, Sessions 1-5.</strong> 15 responses. 73% reported feeling more comfortable in mentoring and leadership positions.</li>
-        <li id="fn17"><strong>[17] Conference financial aid records.</strong> 13 grants across 2024-2026, averaging approximately $300 per grant. Total budget: $2,275.</li>
-        <li id="fn18"><strong>[18] Open source activity data.</strong> Collected via the GitHub API and Django's Trac issue tracker for each program member. Covers pull requests, issues, comments, and review activity across non-personal repositories.</li>
-        <li id="fn19"><strong>[19] Open source activity data.</strong> Collected via the GitHub API for each applicant. Covers pull requests, issues, comments, and review activity across non-personal repositories.</li>
+        <li id="fn2"><strong>[2] GitHub geographic data.</strong> Most closed pull requests come from developers in the US, UK, and Germany. <a href="https://opensourcesurvey.org/2024/">opensourcesurvey.org/2024</a></li>
+        <li id="fn3"><strong>[3] Alison Reynolds and David Lewis, "Teams Solve Problems Faster When They're More Cognitively Diverse," Harvard Business Review, March 2017.</strong> <a href="https://hbr.org/2017/03/teams-solve-problems-faster-when-theyre-more-cognitively-diverse">hbr.org</a></li>
+        <li id="fn4"><strong>[4] IEEE, "Diversity and Inclusion in Open Source Software Projects."</strong> Diverse repositories have superior code quality. <a href="https://ieeexplore.ieee.org/abstract/document/8870179">ieeexplore.ieee.org</a></li>
+        <li id="fn5"><strong>[5] GitHub study on gender bias in code review.</strong> Acceptance drops 12% when gender is identifiable. <a href="https://en.wikipedia.org/wiki/Diversity_in_open-source_software">Wikipedia</a></li>
+        <li id="fn6"><strong>[6] Djangonaut Space program tracking data.</strong> Consolidated from application records and accepted participant lists across Pilot + Sessions 1-6. 104 unique accepted Djangonauts, 680+ applications, 226 total volunteers, 40+ countries. Geographic data available for Sessions 4-6.</li>
+        <li id="fn7"><strong>[7] Applicant experience analysis.</strong> Extracted from freeform application responses. 202 of ~680 applicants (30%) explicitly mentioned years of experience. Accepted sample: 28 of 99.</li>
+        <li id="fn8"><strong>[8] Python Developers Survey 2024, JetBrains/PSF (CC BY 4.0).</strong> 8% of 5,453 OSS contributors identified as women or gender minorities.</li>
+        <li id="fn9"><strong>[9] Djangonaut Space demographics analysis.</strong> Computed from self-reported underrepresented status and gender minority status collected from applicants.</li>
+        <li id="fn10"><strong>[10] Exit surveys, Sessions 1-5.</strong> 32 responses from Djangonauts. 97% feel more comfortable contributing. 53% said growth exceeded expectations.</li>
+        <li id="fn11"><strong>[11] Alumni follow-up survey, 2026.</strong> 24 respondents out of 104 alumni (~23% response rate). Measured post-program contributions, benefits, and before/after confidence across 5 dimensions.</li>
+        <li id="fn12"><strong>[12] Leadership pipeline tracking.</strong> Compiled from program records and alumni survey responses. 22 unique people returning in volunteer roles. Some individuals hold multiple roles.</li>
+        <li id="fn13"><strong>[13] Survey-reported external leadership and conference activity.</strong> Self-reported by 24 alumni survey respondents. 18 of 24 attended conferences or events post-program.</li>
+        <li id="fn14"><strong>[14] Officer exit surveys, Sessions 1-5.</strong> 15 responses. 73% reported feeling more comfortable in mentoring and leadership positions.</li>
+        <li id="fn15"><strong>[15] Conference financial aid records.</strong> 13 grants across 2024-2026, averaging approximately $300 per grant. Total budget: $2,275.</li>
+        <li id="fn16"><strong>[16] Open source activity data.</strong> Collected via the GitHub API and Django's Trac issue tracker for each program member. Covers pull requests, issues, comments, and review activity across non-personal repositories.</li>
+        <li id="fn17"><strong>[17] Open source activity data.</strong> Collected via the GitHub API for each applicant. Covers pull requests, issues, comments, and review activity across non-personal repositories.</li>
       </ol>
     </section>
 


### PR DESCRIPTION
  - Update gender minority stat from ~9% (LF/Harvard FOSS 2020) to 8% (Python Developers Survey 2024, JetBrains/PSF)
  - Add full HBR citation for diverse teams claim (Reynolds & Lewis, 2017)
  - Remove ethnic minorities stat (compared incompatible metrics: GitHub's 'ethnic minorities in country of birth' vs Djangonaut Space's 'underrepresented backgrounds')
  - Replace showcase footnote with inline YouTube link
  - Capitalize Djangonaut, Navigator, and Captain as program role names
  - Renumber footnotes after removals