### PR TITLE
added tailwind docker setup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,8 @@ services:
     # Without tty, no stdin, and tailwind watcher aborts
     # https://github.com/tailwindlabs/tailwindcss/issues/5324
     tty: true
+    env_file:
+      - ./.env.docker
 
   db:
     restart: always


### PR DESCRIPTION
I followed the local setup instructions after not working on the project for a while.

I encountered an issue with tailwind container:

```
tailwind-1  |     raise ValueError("SECRET_KEY environment variable must be set.")

tailwind-1  | ValueError: SECRET_KEY environment variable must be set.
```

This PR adds the missing .env file configuration for the container. 