### PR TITLE
Use docker compose watch to rebuild images on dependency changes

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -232,8 +232,7 @@ Key variables (see `.env.template` files):
 
 ```bash
 # Services
-just up                          # Start all services
-just up-detached                 # Start all services in the background
+just up                          # Start all services, rebuilding on dependency file changes (docker compose up --watch --detached)
 just down                        # Stop all services
 just logs                        # Follow Django logs
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ This is the web application for the Djangonaut Space mentoring program. The plat
 
 2. Have docker running and then run:
    ```sh
-   docker compose up
+   docker compose up --watch
    ```
 
 3. In a new terminal, run any setup commands you need such as

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,15 @@ x-app: &default-app
     - .:/app
   restart: "unless-stopped"
 
+# Rebuild the image automatically when dependency files change, instead of
+# needing a manual --build.
+x-default-watch: &default-watch
+  watch:
+    - action: rebuild
+      path: ./pyproject.toml
+    - action: rebuild
+      path: ./uv.lock
+
 services:
   django:
     <<: *default-app
@@ -20,6 +29,8 @@ services:
       # Later files win, so .env overrides .env.docker for local overrides.
       - ./.env.docker
       - ./.env
+    develop:
+      <<: *default-watch
 
   worker:
     <<: *default-app
@@ -30,6 +41,8 @@ services:
       # Later files win, so .env overrides .env.docker for local overrides.
       - ./.env.docker
       - ./.env
+    develop:
+      <<: *default-watch
 
   tailwind:
     <<: *default-app
@@ -46,6 +59,16 @@ services:
       # Later files win, so .env overrides .env.docker for local overrides.
       - ./.env.docker
       - ./.env
+    develop:
+      watch:
+        - action: rebuild
+          path: ./pyproject.toml
+        - action: rebuild
+          path: ./uv.lock
+        - action: rebuild
+          path: ./theme/static_src/package.json
+        - action: rebuild
+          path: ./theme/static_src/package-lock.json
 
   db:
     restart: always

--- a/justfile
+++ b/justfile
@@ -3,13 +3,9 @@
 
 django := "docker compose exec django"
 
-# Start all services
-up:
-    docker compose up
-
-# Start all services in the background
-up-detached:
-    docker compose up -d
+# Start all services in the background with file watching. Pass --attached to stream logs in the foreground instead.
+up attached="":
+    docker compose {{ if attached == "--attached" { "up --watch" } else { "watch" } }}
 
 # Stop all services
 down:


### PR DESCRIPTION
Replace the plain `docker compose up`/`up-detached` split with `just up`, which runs `docker compose watch` in the background by default (or `up --watch` in the foreground with --attached) so django, worker, and tailwind rebuild automatically when pyproject.toml/uv.lock or the tailwind package files change instead of requiring a manual --build.

Closes #804