### PR TITLE
Speed up Playwright test database creation with a migrated template

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -262,7 +262,6 @@ just test-playwright-headed      # Playwright tests with visible browser
 # Tailwind
 just tailwind-install
 just tailwind-start
-just tailwind-build              # Production build
 
 # GitHub Actions Security
 just zizmor                      # Check all workflows

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -73,7 +73,14 @@ jobs:
       - name: Run tests
         run: uv run pytest -n auto --cov --cov-branch --cov-report=xml --cov-report=term
 
+      - name: Build test database template
+        env:
+          TEST_DB_TEMPLATE: template_wagtail_indymeet_test
+        run: uv run python manage.py build_test_db_template
+
       - name: Run playwright tests
+        env:
+          TEST_DB_TEMPLATE: template_wagtail_indymeet_test
         run: uv run pytest --tracing retain-on-failure -m playwright -n auto --cov --cov-branch --cov-report=xml --cov-append --cov-report=term
 
       - name: Upload results to Codecov

--- a/README.md
+++ b/README.md
@@ -166,15 +166,15 @@ To run the tests:
 docker compose exec django uv run pytest
 ```
 
-There are also Playwright tests that can be run. To run these tests:
+To run the Playwright tests:
 
 ```shell
 # Be sure playwright is properly installed and has a test user for accessing /admin
 docker compose exec django uv run playwright install --with-deps
 # This is the actual test command
-docker compose exec django uv run pytest -m playwright
+just test-playwright
 # Run the tests in headed mode (so you can see the browser)
-docker compose exec django uv run pytest -m playwright --headed
+just test-playwright-headed
 ```
 
 ### Merging changes

--- a/home/management/commands/build_test_db_template.py
+++ b/home/management/commands/build_test_db_template.py
@@ -1,0 +1,100 @@
+"""
+Build (or refresh) the migrated template database referenced by
+``DATABASES[...]["TEST"]["TEMPLATE"]`` (see ``indymeet/settings.py``).
+
+Postgres can copy an already-migrated database far faster than Django can
+replay every Wagtail + application migration, which matters most for
+pytest-xdist, where each worker builds its own test database from scratch.
+
+Application migrations change often enough that a stale template is a real
+risk, so this command checks whether the template already reflects every
+migration before doing the expensive rebuild. That makes it safe to run
+before every Playwright test run instead of relying on remembering to re-run
+it after pulling migrations.
+"""
+
+from django.core.management.base import BaseCommand, CommandError
+from django.db import DatabaseError, connections
+from django.db.migrations.executor import MigrationExecutor
+
+
+class Command(BaseCommand):
+    help = (
+        "Build/refresh the migrated template database referenced by "
+        "DATABASES[...]['TEST']['TEMPLATE'], used to seed the test database for "
+        "the Playwright suite instead of replaying every migration. Skips the "
+        "rebuild when the template already reflects every migration, so it's "
+        "safe to run before every Playwright test run."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--database",
+            default="default",
+            dest="alias",
+            help="Alias of the database whose TEST TEMPLATE should be (re)built.",
+        )
+        parser.add_argument(
+            "--force",
+            action="store_true",
+            help="Rebuild the template even if it already reflects every migration.",
+        )
+
+    def handle(self, *args, alias, force, **options):
+        connection = connections[alias]
+        test_settings = connection.settings_dict.setdefault("TEST", {})
+
+        match test_settings.get("TEMPLATE"):
+            case None | "":
+                raise CommandError(
+                    f"DATABASES['{alias}']['TEST']['TEMPLATE'] is not configured."
+                )
+            case template_name:
+                original_name = connection.settings_dict["NAME"]
+                original_test_name = test_settings.get("NAME")
+
+        if not force and self._is_up_to_date(connection, template_name):
+            self.stdout.write(
+                f'Test database template "{template_name}" already reflects '
+                "every migration; skipping rebuild."
+            )
+            return
+
+        # Build the template as a plain database rather than cloning it from
+        # itself.
+        del test_settings["TEMPLATE"]
+        test_settings["NAME"] = template_name
+
+        try:
+            connection.creation.create_test_db(
+                verbosity=options["verbosity"],
+                autoclobber=True,
+                serialize=False,
+                keepdb=False,
+            )
+        finally:
+            connection.close()
+            test_settings["TEMPLATE"] = template_name
+            test_settings["NAME"] = original_test_name
+            connection.settings_dict["NAME"] = original_name
+
+        self.stdout.write(
+            self.style.SUCCESS(f'Built test database template "{template_name}".')
+        )
+
+    def _is_up_to_date(self, connection, template_name):
+        """Whether template_name already has every migration applied."""
+        original_name = connection.settings_dict["NAME"]
+        connection.settings_dict["NAME"] = template_name
+        connection.close()
+        try:
+            executor = MigrationExecutor(connection)
+        except DatabaseError:
+            # The template database doesn't exist yet (or can't be reached);
+            # treat that as stale so it gets built.
+            return False
+        else:
+            return not executor.migration_plan(executor.loader.graph.leaf_nodes())
+        finally:
+            connection.close()
+            connection.settings_dict["NAME"] = original_name

--- a/home/tests/test_build_test_db_template.py
+++ b/home/tests/test_build_test_db_template.py
@@ -1,0 +1,202 @@
+from io import StringIO
+from unittest import mock
+
+from django.core import management
+from django.core.management import CommandError
+from django.db import DatabaseError
+from django.test import SimpleTestCase
+
+from home.management.commands.build_test_db_template import Command
+
+
+class FakeCreation:
+    def __init__(self):
+        self.create_test_db = mock.Mock()
+
+
+class FakeConnection:
+    def __init__(self, settings_dict):
+        self.settings_dict = settings_dict
+        self.creation = FakeCreation()
+        self.close = mock.Mock()
+
+
+class BuildTestDbTemplateCommandTests(SimpleTestCase):
+    def _settings_dict(self, template="template_wagtail_indymeet_test"):
+        return {
+            "NAME": "djangonaut-space",
+            "TEST": {"TEMPLATE": template} if template else {},
+        }
+
+    def test_raises_when_template_not_configured(self):
+        connection = FakeConnection(self._settings_dict(template=None))
+
+        with mock.patch(
+            "home.management.commands.build_test_db_template.connections",
+            {"default": connection},
+        ):
+            with self.assertRaisesMessage(
+                CommandError,
+                "DATABASES['default']['TEST']['TEMPLATE'] is not configured.",
+            ):
+                management.call_command("build_test_db_template", stdout=StringIO())
+
+        connection.creation.create_test_db.assert_not_called()
+
+    def test_skips_rebuild_when_already_up_to_date(self):
+        connection = FakeConnection(self._settings_dict())
+
+        out = StringIO()
+        with (
+            mock.patch(
+                "home.management.commands.build_test_db_template.connections",
+                {"default": connection},
+            ),
+            mock.patch.object(
+                Command, "_is_up_to_date", return_value=True
+            ) as is_up_to_date,
+        ):
+            management.call_command("build_test_db_template", stdout=out)
+
+        is_up_to_date.assert_called_once_with(
+            connection, "template_wagtail_indymeet_test"
+        )
+        connection.creation.create_test_db.assert_not_called()
+        self.assertIn("already reflects every migration", out.getvalue())
+
+    def test_force_rebuilds_without_checking_up_to_date(self):
+        connection = FakeConnection(self._settings_dict())
+
+        with (
+            mock.patch(
+                "home.management.commands.build_test_db_template.connections",
+                {"default": connection},
+            ),
+            mock.patch.object(Command, "_is_up_to_date") as is_up_to_date,
+        ):
+            management.call_command(
+                "build_test_db_template", "--force", stdout=StringIO()
+            )
+
+        is_up_to_date.assert_not_called()
+        connection.creation.create_test_db.assert_called_once()
+
+    def test_builds_template_as_plain_database_and_restores_settings(self):
+        settings_dict = self._settings_dict()
+        connection = FakeConnection(settings_dict)
+        captured_test_settings_during_build = {}
+
+        def capture_settings(*args, **kwargs):
+            captured_test_settings_during_build.update(settings_dict["TEST"])
+
+        connection.creation.create_test_db.side_effect = capture_settings
+
+        out = StringIO()
+        with (
+            mock.patch(
+                "home.management.commands.build_test_db_template.connections",
+                {"default": connection},
+            ),
+            mock.patch.object(Command, "_is_up_to_date", return_value=False),
+        ):
+            management.call_command("build_test_db_template", stdout=out)
+
+        connection.creation.create_test_db.assert_called_once_with(
+            verbosity=1, autoclobber=True, serialize=False, keepdb=False
+        )
+        # While building, the template is a plain database (no TEMPLATE key)
+        # named after the template, not cloned from itself.
+        self.assertNotIn("TEMPLATE", captured_test_settings_during_build)
+        self.assertEqual(
+            captured_test_settings_during_build["NAME"],
+            "template_wagtail_indymeet_test",
+        )
+
+        # Settings are restored afterwards.
+        self.assertEqual(
+            settings_dict["TEST"]["TEMPLATE"], "template_wagtail_indymeet_test"
+        )
+        self.assertIsNone(settings_dict["TEST"]["NAME"])
+        self.assertEqual(settings_dict["NAME"], "djangonaut-space")
+        connection.close.assert_called_once()
+
+        self.assertIn(
+            'Built test database template "template_wagtail_indymeet_test".',
+            out.getvalue(),
+        )
+
+    def test_restores_settings_even_when_create_test_db_fails(self):
+        settings_dict = self._settings_dict()
+        connection = FakeConnection(settings_dict)
+        connection.creation.create_test_db.side_effect = Exception("boom")
+
+        with (
+            mock.patch(
+                "home.management.commands.build_test_db_template.connections",
+                {"default": connection},
+            ),
+            mock.patch.object(Command, "_is_up_to_date", return_value=False),
+        ):
+            with self.assertRaisesMessage(Exception, "boom"):
+                management.call_command("build_test_db_template", stdout=StringIO())
+
+        self.assertEqual(
+            settings_dict["TEST"]["TEMPLATE"], "template_wagtail_indymeet_test"
+        )
+        self.assertEqual(settings_dict["NAME"], "djangonaut-space")
+
+
+class IsUpToDateTests(SimpleTestCase):
+    def _connection(self):
+        return FakeConnection(
+            {
+                "NAME": "djangonaut-space",
+                "TEST": {"TEMPLATE": "template_wagtail_indymeet_test"},
+            }
+        )
+
+    def test_returns_false_and_restores_name_when_database_is_unreachable(self):
+        connection = self._connection()
+
+        with mock.patch(
+            "home.management.commands.build_test_db_template.MigrationExecutor",
+            side_effect=DatabaseError("database does not exist"),
+        ):
+            result = Command()._is_up_to_date(
+                connection, "template_wagtail_indymeet_test"
+            )
+
+        self.assertFalse(result)
+        self.assertEqual(connection.settings_dict["NAME"], "djangonaut-space")
+        connection.close.assert_called()
+
+    def test_returns_true_when_no_migrations_are_pending(self):
+        connection = self._connection()
+        executor = mock.Mock()
+        executor.migration_plan.return_value = []
+
+        with mock.patch(
+            "home.management.commands.build_test_db_template.MigrationExecutor",
+            return_value=executor,
+        ):
+            result = Command()._is_up_to_date(
+                connection, "template_wagtail_indymeet_test"
+            )
+
+        self.assertTrue(result)
+        self.assertEqual(connection.settings_dict["NAME"], "djangonaut-space")
+
+    def test_returns_false_when_migrations_are_pending(self):
+        connection = self._connection()
+        executor = mock.Mock()
+        executor.migration_plan.return_value = [("home", "0002_something")]
+
+        with mock.patch(
+            "home.management.commands.build_test_db_template.MigrationExecutor",
+            return_value=executor,
+        ):
+            result = Command()._is_up_to_date(
+                connection, "template_wagtail_indymeet_test"
+            )
+
+        self.assertFalse(result)

--- a/indymeet/settings.py
+++ b/indymeet/settings.py
@@ -126,6 +126,15 @@ DATABASES = {
     )
 }
 
+# When TEST_DB_TEMPLATE is set, Postgres clones that already-migrated database
+# when pytest-django/pytest-xdist build a test database, instead of replaying
+# every migration. Unset (the default) leaves test database creation
+# unaffected. Used for the Playwright suite via `just test-playwright`; see
+# `just build-test-db-template`.
+DATABASES["default"]["TEST"] = {
+    "TEMPLATE": os.getenv("TEST_DB_TEMPLATE", ""),
+}
+
 CACHES = {
     "default": {
         "BACKEND": "django.core.cache.backends.locmem.LocMemCache",

--- a/justfile
+++ b/justfile
@@ -24,21 +24,9 @@ logs:
 shell:
     {{django}} uv run python manage.py shell
 
-# Open a database shell
-dbshell:
-    {{django}} uv run python manage.py dbshell
-
 # Create a superuser
 superuser:
     {{django}} uv run python manage.py createsuperuser
-
-# Create a demo session
-demo:
-    {{django}} uv run python manage.py generate_sample_session
-
-# Bootstrap a Discord server
-bootstrap_discord:
-    {{django}} uv run python manage.py bootstrap_discord_server
 
 # Run database migrations
 migrate *args:
@@ -47,6 +35,18 @@ migrate *args:
 # Create new migrations
 makemigrations *args:
     {{django}} uv run python manage.py makemigrations {{args}}
+
+# Open a database shell
+dbshell:
+    {{django}} uv run python manage.py dbshell
+
+# Create a demo session
+bootstrap_session:
+    {{django}} uv run python manage.py generate_sample_session
+
+# Bootstrap a Discord server
+bootstrap_discord:
+    {{django}} uv run python manage.py bootstrap_discord_server
 
 # Build/refresh the migrated template database used to speed up Playwright test database
 # creation. Skips the rebuild when the template already reflects every migration, so it's
@@ -57,10 +57,6 @@ build-test-db-template *args:
 # Run all tests (excluding Playwright)
 test *args:
     {{django}} uv run pytest -n auto {{args}}
-
-# Run tests with database reuse
-test-fast *args:
-    {{django}} uv run pytest --reuse-db -n auto {{args}}
 
 # Install Playwright browsers and run Playwright tests
 test-playwright *args:
@@ -80,10 +76,6 @@ tailwind-install:
 # Start Tailwind CSS watcher
 tailwind-start:
     {{django}} uv run python manage.py tailwind start
-
-# Build Tailwind CSS for production
-tailwind-build:
-    {{django}} uv run python manage.py tailwind build
 
 # Dump database fixtures (excludes system tables)
 dumpdata:

--- a/justfile
+++ b/justfile
@@ -3,6 +3,11 @@
 
 django := "docker compose exec django"
 
+# Name of the migrated template database Postgres clones for Playwright test
+# database creation instead of replaying every migration (see indymeet/settings.py).
+test_db_template := "template_wagtail_indymeet_test"
+django_playwright := "docker compose exec -e TEST_DB_TEMPLATE=" + test_db_template + " django"
+
 # Start all services in the background with file watching. Pass --attached to stream logs in the foreground instead.
 up attached="":
     docker compose {{ if attached == "--attached" { "up --watch" } else { "watch" } }}
@@ -43,6 +48,12 @@ migrate *args:
 makemigrations *args:
     {{django}} uv run python manage.py makemigrations {{args}}
 
+# Build/refresh the migrated template database used to speed up Playwright test database
+# creation. Skips the rebuild when the template already reflects every migration, so it's
+# safe to run unconditionally; test-playwright/test-playwright-headed do this automatically.
+build-test-db-template *args:
+    {{django_playwright}} uv run python manage.py build_test_db_template {{args}}
+
 # Run all tests (excluding Playwright)
 test *args:
     {{django}} uv run pytest -n auto {{args}}
@@ -54,11 +65,13 @@ test-fast *args:
 # Install Playwright browsers and run Playwright tests
 test-playwright *args:
     {{django}} uv run playwright install --with-deps
-    {{django}} uv run pytest -m playwright -n auto {{args}}
+    just build-test-db-template {{ if args =~ '--create-db' { "--force" } else { "" } }}
+    {{django_playwright}} uv run pytest -m playwright -n auto {{args}}
 
 # Run Playwright tests in headed mode (visible browser)
 test-playwright-headed *args:
-    {{django}} uv run pytest -m playwright --headed {{args}}
+    just build-test-db-template {{ if args =~ '--create-db' { "--force" } else { "" } }}
+    {{django_playwright}} uv run pytest -m playwright --headed {{args}}
 
 # Install Tailwind dependencies
 tailwind-install:


### PR DESCRIPTION
pytest-xdist has every worker build its own test database from scratch, which means replaying the full migration history per worker. Add a build_test_db_template management command that maintains a Postgres template database with migrations already applied (skipping the rebuild when it's already up to date).

Closes #806