### PR TITLE
test: add test coverage for Discord scheduled event update path

### DIFF
--- a/home/tests/test_discord.py
+++ b/home/tests/test_discord.py
@@ -228,9 +228,7 @@ class DiscordClientRequestTests(TestCase):
     def test_logs_response_body_and_reraises_on_http_error(self):
         rsps.add(rsps.GET, f"{BASE_URL}/foo", status=403, body="boom")
 
-        with self.assertLogs(
-            "home.integrations.discord.client", level="ERROR"
-        ) as logs:
+        with self.assertLogs("home.integrations.discord.client", level="ERROR") as logs:
             with self.assertRaises(requests.HTTPError):
                 self.client._request("GET", "/foo")
 

--- a/home/tests/test_discord.py
+++ b/home/tests/test_discord.py
@@ -7,7 +7,7 @@ Tests for Discord integration: DiscordClient, the discord service
 import json
 from datetime import datetime as dt
 from datetime import timezone as dt_timezone
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import requests
 import responses as rsps
@@ -55,35 +55,37 @@ class DiscordEnabledTests(TestCase):
 
 
 class DiscordClientScheduledEventTests(TestCase):
+    """DiscordClient scheduled-event methods, over HTTP stubbed with responses.
+
+    The real client, payload serialization, and URL construction run against
+    the stubbed endpoints; assertions read the request body responses captured.
+    """
+
     def setUp(self):
         self.client = DiscordClient()
 
-    def _mock_request(self, event_id="987654321"):
-        resp = MagicMock()
-        resp.json.return_value = {
-            "id": event_id,
-            "name": "Test Event",
-            "entity_type": 3,
-        }
-        return patch.object(self.client, "_request", return_value=resp)
-
     @override_settings(**DISCORD_SETTINGS)
+    @rsps.activate
     def test_payload_shape(self):
         start = dt(2026, 6, 1, 14, 0, tzinfo=UTC)
         end = dt(2026, 6, 1, 15, 0, tzinfo=UTC)
+        rsps.add(
+            rsps.POST,
+            f"{BASE_URL}/guilds/123/scheduled-events",
+            json={"id": "987654321"},
+        )
 
-        with self._mock_request() as mock_req:
-            self.client.create_scheduled_event(
-                guild_id="123",
-                name="My Event",
-                description="A description",
-                location="https://zoom.us/j/123",
-                start_time=start,
-                end_time=end,
-            )
+        self.client.create_scheduled_event(
+            guild_id="123",
+            name="My Event",
+            description="A description",
+            location="https://zoom.us/j/123",
+            start_time=start,
+            end_time=end,
+        )
 
         self.assertEqual(
-            mock_req.call_args.kwargs["json"],
+            json.loads(rsps.calls[0].request.body),
             {
                 "name": "My Event",
                 "description": "A description",
@@ -96,124 +98,141 @@ class DiscordClientScheduledEventTests(TestCase):
         )
 
     @override_settings(**DISCORD_SETTINGS)
+    @rsps.activate
     def test_sends_fields_unchanged(self):
         start = dt(2026, 6, 1, 14, 0, tzinfo=UTC)
         end = dt(2026, 6, 1, 15, 0, tzinfo=UTC)
+        rsps.add(
+            rsps.POST,
+            f"{BASE_URL}/guilds/123/scheduled-events",
+            json={"id": "987654321"},
+        )
 
-        with self._mock_request() as mock_req:
-            self.client.create_scheduled_event(
-                guild_id="123",
-                name="x" * 200,
-                description="y" * 2000,
-                location="z" * 200,
-                start_time=start,
-                end_time=end,
-            )
+        self.client.create_scheduled_event(
+            guild_id="123",
+            name="x" * 200,
+            description="y" * 2000,
+            location="z" * 200,
+            start_time=start,
+            end_time=end,
+        )
 
-        payload = mock_req.call_args.kwargs["json"]
+        payload = json.loads(rsps.calls[0].request.body)
 
         self.assertEqual(len(payload["name"]), 200)
         self.assertEqual(len(payload["description"]), 2000)
         self.assertEqual(len(payload["entity_metadata"]["location"]), 200)
 
     @override_settings(**DISCORD_SETTINGS)
+    @rsps.activate
     def test_handles_null_description(self):
         start = dt(2026, 6, 1, 14, 0, tzinfo=UTC)
         end = dt(2026, 6, 1, 15, 0, tzinfo=UTC)
+        rsps.add(
+            rsps.POST,
+            f"{BASE_URL}/guilds/123/scheduled-events",
+            json={"id": "987654321"},
+        )
 
-        with self._mock_request() as mock_req:
-            self.client.create_scheduled_event(
-                guild_id="123",
-                name="x",
-                description=None,
-                location="https://zoom.us/j/1",
-                start_time=start,
-                end_time=end,
-            )
+        self.client.create_scheduled_event(
+            guild_id="123",
+            name="x",
+            description=None,
+            location="https://zoom.us/j/1",
+            start_time=start,
+            end_time=end,
+        )
 
-        self.assertEqual(mock_req.call_args.kwargs["json"]["description"], "")
+        self.assertEqual(json.loads(rsps.calls[0].request.body)["description"], "")
 
     @override_settings(**DISCORD_SETTINGS)
+    @rsps.activate
     def test_sends_patch_to_scoped_event_url(self):
-        with self._mock_request() as mock_req:
-            self.client.modify_scheduled_event(
-                guild_id="123",
-                event_id="event-1",
-                payload={"name": "Renamed"},
-            )
+        rsps.add(
+            rsps.PATCH,
+            f"{BASE_URL}/guilds/123/scheduled-events/event-1",
+            json={"id": "event-1"},
+        )
 
+        self.client.modify_scheduled_event(
+            guild_id="123",
+            event_id="event-1",
+            payload={"name": "Renamed"},
+        )
+
+        self.assertEqual(rsps.calls[0].request.method, "PATCH")
         self.assertEqual(
-            mock_req.call_args.args,
-            ("PATCH", "/guilds/123/scheduled-events/event-1"),
+            rsps.calls[0].request.url,
+            f"{BASE_URL}/guilds/123/scheduled-events/event-1",
         )
 
     @override_settings(**DISCORD_SETTINGS)
+    @rsps.activate
     def test_forwards_payload_unchanged(self):
         payload = {
             "name": "Renamed",
             "entity_metadata": {"location": "https://zoom.us/j/999"},
         }
+        rsps.add(
+            rsps.PATCH,
+            f"{BASE_URL}/guilds/123/scheduled-events/event-1",
+            json={"id": "event-1"},
+        )
 
-        with self._mock_request() as mock_req:
-            self.client.modify_scheduled_event(
-                guild_id="123",
-                event_id="event-1",
-                payload=payload,
-            )
+        self.client.modify_scheduled_event(
+            guild_id="123",
+            event_id="event-1",
+            payload=payload,
+        )
 
-        self.assertEqual(mock_req.call_args.kwargs["json"], payload)
+        self.assertEqual(json.loads(rsps.calls[0].request.body), payload)
 
     @override_settings(**DISCORD_SETTINGS)
+    @rsps.activate
     def test_returns_updated_event_json(self):
-        with self._mock_request(event_id="event-1") as mock_req:
-            result = self.client.modify_scheduled_event(
-                guild_id="123",
-                event_id="event-1",
-                payload={"name": "Renamed"},
-            )
+        rsps.add(
+            rsps.PATCH,
+            f"{BASE_URL}/guilds/123/scheduled-events/event-1",
+            json={"id": "event-1", "name": "Renamed"},
+        )
 
-        self.assertEqual(result, mock_req.return_value.json.return_value)
+        result = self.client.modify_scheduled_event(
+            guild_id="123",
+            event_id="event-1",
+            payload={"name": "Renamed"},
+        )
+
+        self.assertEqual(result, {"id": "event-1", "name": "Renamed"})
 
 
 class DiscordClientRequestTests(TestCase):
+    """The shared _request helper: auth header, rate-limit logging, and error
+    handling, exercised over HTTP stubbed with responses."""
+
     def setUp(self):
         self.client = DiscordClient()
 
     @override_settings(**DISCORD_SETTINGS)
+    @rsps.activate
     def test_sets_bot_authorization_header(self):
-        resp = MagicMock(status_code=200)
-        resp.raise_for_status.return_value = None
+        rsps.add(rsps.GET, f"{BASE_URL}/foo", json={})
 
-        with patch.object(
-            self.client.session, "request", return_value=resp
-        ) as mock_req:
-            self.client._request("GET", "/foo")
+        self.client._request("GET", "/foo")
 
-        headers = mock_req.call_args.kwargs["headers"]
-        self.assertEqual(headers["Authorization"], "Bot bot-token")
+        self.assertEqual(
+            rsps.calls[0].request.headers["Authorization"], "Bot bot-token"
+        )
 
     @override_settings(**DISCORD_SETTINGS)
-    def test_logs_on_429(self):
-        resp = MagicMock(status_code=429)
-        resp.raise_for_status.side_effect = Exception("429")
-
-        with patch.object(self.client.session, "request", return_value=resp):
-            with self.assertLogs("home.integrations.discord.client", level="ERROR"):
-                with self.assertRaises(Exception):
-                    self.client._request("GET", "/foo")
-
-    @override_settings(**DISCORD_SETTINGS)
+    @rsps.activate
     def test_logs_response_body_and_reraises_on_http_error(self):
-        resp = MagicMock(status_code=500)
-        resp.text = "boom"
-        resp.raise_for_status.side_effect = requests.HTTPError(response=resp)
+        rsps.add(rsps.GET, f"{BASE_URL}/foo", status=403, body="boom")
 
-        with patch.object(self.client.session, "request", return_value=resp):
-            with self.assertLogs(
-                "home.integrations.discord.client", level="ERROR"
-            ) as logs:
-                with self.assertRaises(requests.HTTPError):
-                    self.client._request("GET", "/foo")
+        with self.assertLogs(
+            "home.integrations.discord.client", level="ERROR"
+        ) as logs:
+            with self.assertRaises(requests.HTTPError):
+                self.client._request("GET", "/foo")
 
         self.assertIn("boom", "\n".join(logs.output))
 

--- a/home/tests/test_discord.py
+++ b/home/tests/test_discord.py
@@ -38,11 +38,11 @@ UTC = dt_timezone.utc
 
 
 class DiscordEnabledTests(TestCase):
-    def test_returns_true_when_credentials_present(self):
+    def test_true_with_credentials(self):
         with override_settings(**DISCORD_SETTINGS):
             self.assertTrue(discord_enabled())
 
-    def test_returns_false_when_any_credential_missing(self):
+    def test_false_missing_credential(self):
         cases = [
             dict(DISCORD_BOT_TOKEN="", DISCORD_GUILD_ID="123"),
             dict(DISCORD_BOT_TOKEN="tok", DISCORD_GUILD_ID=""),
@@ -66,7 +66,7 @@ class DiscordClientScheduledEventTests(TestCase):
 
     @override_settings(**DISCORD_SETTINGS)
     @rsps.activate
-    def test_payload_shape(self):
+    def test_create_payload(self):
         start = dt(2026, 6, 1, 14, 0, tzinfo=UTC)
         end = dt(2026, 6, 1, 15, 0, tzinfo=UTC)
         rsps.add(
@@ -99,7 +99,9 @@ class DiscordClientScheduledEventTests(TestCase):
 
     @override_settings(**DISCORD_SETTINGS)
     @rsps.activate
-    def test_sends_fields_unchanged(self):
+    def test_create_long_fields(self):
+        """Name/description/location aren't truncated, even at Discord's own
+        length limits."""
         start = dt(2026, 6, 1, 14, 0, tzinfo=UTC)
         end = dt(2026, 6, 1, 15, 0, tzinfo=UTC)
         rsps.add(
@@ -125,7 +127,8 @@ class DiscordClientScheduledEventTests(TestCase):
 
     @override_settings(**DISCORD_SETTINGS)
     @rsps.activate
-    def test_handles_null_description(self):
+    def test_create_null_description(self):
+        """A null description is sent to Discord as an empty string."""
         start = dt(2026, 6, 1, 14, 0, tzinfo=UTC)
         end = dt(2026, 6, 1, 15, 0, tzinfo=UTC)
         rsps.add(
@@ -147,49 +150,13 @@ class DiscordClientScheduledEventTests(TestCase):
 
     @override_settings(**DISCORD_SETTINGS)
     @rsps.activate
-    def test_sends_patch_to_scoped_event_url(self):
-        rsps.add(
-            rsps.PATCH,
-            f"{BASE_URL}/guilds/123/scheduled-events/event-1",
-            json={"id": "event-1"},
-        )
-
-        self.client.modify_scheduled_event(
-            guild_id="123",
-            event_id="event-1",
-            payload={"name": "Renamed"},
-        )
-
-        self.assertEqual(rsps.calls[0].request.method, "PATCH")
-        self.assertEqual(
-            rsps.calls[0].request.url,
-            f"{BASE_URL}/guilds/123/scheduled-events/event-1",
-        )
-
-    @override_settings(**DISCORD_SETTINGS)
-    @rsps.activate
-    def test_forwards_payload_unchanged(self):
+    def test_modify_payload(self):
+        """PATCHes the guild-scoped event URL, forwarding the payload
+        unchanged, and returns Discord's response JSON."""
         payload = {
             "name": "Renamed",
             "entity_metadata": {"location": "https://zoom.us/j/999"},
         }
-        rsps.add(
-            rsps.PATCH,
-            f"{BASE_URL}/guilds/123/scheduled-events/event-1",
-            json={"id": "event-1"},
-        )
-
-        self.client.modify_scheduled_event(
-            guild_id="123",
-            event_id="event-1",
-            payload=payload,
-        )
-
-        self.assertEqual(json.loads(rsps.calls[0].request.body), payload)
-
-    @override_settings(**DISCORD_SETTINGS)
-    @rsps.activate
-    def test_returns_updated_event_json(self):
         rsps.add(
             rsps.PATCH,
             f"{BASE_URL}/guilds/123/scheduled-events/event-1",
@@ -199,9 +166,15 @@ class DiscordClientScheduledEventTests(TestCase):
         result = self.client.modify_scheduled_event(
             guild_id="123",
             event_id="event-1",
-            payload={"name": "Renamed"},
+            payload=payload,
         )
 
+        self.assertEqual(rsps.calls[0].request.method, "PATCH")
+        self.assertEqual(
+            rsps.calls[0].request.url,
+            f"{BASE_URL}/guilds/123/scheduled-events/event-1",
+        )
+        self.assertEqual(json.loads(rsps.calls[0].request.body), payload)
         self.assertEqual(result, {"id": "event-1", "name": "Renamed"})
 
 
@@ -214,7 +187,7 @@ class DiscordClientRequestTests(TestCase):
 
     @override_settings(**DISCORD_SETTINGS)
     @rsps.activate
-    def test_sets_bot_authorization_header(self):
+    def test_auth_header(self):
         rsps.add(rsps.GET, f"{BASE_URL}/foo", json={})
 
         self.client._request("GET", "/foo")
@@ -225,7 +198,8 @@ class DiscordClientRequestTests(TestCase):
 
     @override_settings(**DISCORD_SETTINGS)
     @rsps.activate
-    def test_logs_response_body_and_reraises_on_http_error(self):
+    def test_http_error(self):
+        """Logs the response body, then re-raises."""
         rsps.add(rsps.GET, f"{BASE_URL}/foo", status=403, body="boom")
 
         with self.assertLogs("home.integrations.discord.client", level="ERROR") as logs:
@@ -241,14 +215,14 @@ class PrepareFieldsTests(TestCase):
         defaults.update(kwargs)
         return EventFactory.build(**defaults)
 
-    def test_returns_fields_unchanged_when_within_limits(self):
+    def test_within_limits(self):
         result = _prepare_fields(self._event(description="A description"))
         self.assertEqual(
             result,
             ("My Event", "A description", "https://zoom.us/j/1"),
         )
 
-    def test_passes_through_title_and_description_without_truncating(self):
+    def test_no_truncation(self):
         """Name/description caps are enforced on the model, so the service no
         longer truncates them; it passes whatever it's given straight through."""
         event = self._event(title="x" * 200, description="y" * 2000)
@@ -258,7 +232,7 @@ class PrepareFieldsTests(TestCase):
         self.assertEqual(len(name), 200)
         self.assertEqual(len(description), 2000)
 
-    def test_raises_on_over_long_zoom_link(self):
+    def test_long_zoom_link_raises(self):
         event = self._event(zoom_link="https://zoom.us/j/" + "z" * 100)
         with self.assertRaises(ValueError):
             _prepare_fields(event)
@@ -274,7 +248,7 @@ class UpdateEventTests(TestCase):
 
     @override_settings(**DISCORD_SETTINGS)
     @rsps.activate
-    def test_builds_expected_modify_payload(self):
+    def test_payload(self):
         event = EventFactory.build(
             title="My Event",
             description="A description",
@@ -303,7 +277,8 @@ class UpdateEventTests(TestCase):
 
     @override_settings(**DISCORD_SETTINGS)
     @rsps.activate
-    def test_raises_on_over_long_zoom_link_without_calling_discord(self):
+    def test_long_zoom_link_raises(self):
+        """Validated before Discord is called, so no request is made."""
         event = EventFactory.build(
             title="My Event",
             zoom_link="https://zoom.us/j/" + "z" * 100,
@@ -326,7 +301,7 @@ class SyncEventDiscordTests(TestCase):
 
     @override_settings(DISCORD_BOT_TOKEN="", DISCORD_GUILD_ID="")
     @patch("home.tasks.sync_event.create_event")
-    def test_skips_when_discord_not_configured(self, mock_create):
+    def test_skips_unconfigured(self, mock_create):
         event = EventFactory.create(zoom_link="https://zoom.us/j/abc")
 
         sync_event.call(event_id=event.pk)
@@ -335,14 +310,14 @@ class SyncEventDiscordTests(TestCase):
 
     @override_settings(**DISCORD_SETTINGS)
     @patch("home.tasks.sync_event.create_event")
-    def test_handles_missing_event(self, mock_create):
+    def test_missing_event(self, mock_create):
         sync_event.call(event_id=999999)
 
         mock_create.assert_not_called()
 
     @override_settings(**DISCORD_SETTINGS)
     @patch("home.tasks.sync_event.create_event")
-    def test_creates_event_and_writes_id(self, mock_create):
+    def test_create(self, mock_create):
         mock_create.return_value = "discord-id-42"
         event = EventFactory.create(zoom_link="https://zoom.us/j/abc")
 
@@ -354,7 +329,7 @@ class SyncEventDiscordTests(TestCase):
 
     @override_settings(**DISCORD_SETTINGS)
     @patch("home.tasks.sync_event.create_event")
-    def test_skips_when_zoom_link_missing(self, mock_create):
+    def test_skips_no_zoom_link(self, mock_create):
         event = EventFactory.create(zoom_link="")
 
         sync_event.call(event_id=event.pk)
@@ -363,7 +338,7 @@ class SyncEventDiscordTests(TestCase):
 
     @override_settings(**DISCORD_SETTINGS)
     @patch("home.tasks.sync_event.update_event")
-    def test_updates_when_discord_event_id_present(self, mock_update):
+    def test_update(self, mock_update):
         event = EventFactory.create(
             zoom_link="https://zoom.us/j/existing",
             discord_event_id="discord-456",
@@ -377,7 +352,8 @@ class SyncEventDiscordTests(TestCase):
 
     @override_settings(**DISCORD_SETTINGS)
     @patch("home.tasks.sync_event.create_event")
-    def test_create_error_leaves_id_empty(self, mock_create):
+    def test_create_error(self, mock_create):
+        """A failed create leaves discord_event_id/synced_at unset."""
         mock_create.side_effect = Exception("Discord API down")
         event = EventFactory.create(zoom_link="https://zoom.us/j/abc")
 
@@ -395,7 +371,7 @@ class SyncEventZoomThenDiscordTests(TestCase):
     @override_settings(**ZOOM_SETTINGS, **DISCORD_SETTINGS)
     @patch("home.tasks.sync_event.create_event")
     @patch("home.tasks.sync_event.create_event_meeting")
-    def test_one_run_creates_both(self, mock_zoom, mock_discord):
+    def test_creates_both(self, mock_zoom, mock_discord):
         mock_zoom.return_value = ZoomMeeting("https://zoom.us/j/x", "999")
         mock_discord.return_value = "discord-1"
         event = EventFactory.create(zoom_link="")

--- a/home/tests/test_discord.py
+++ b/home/tests/test_discord.py
@@ -52,7 +52,7 @@ class DiscordEnabledTests(TestCase):
                 self.assertFalse(discord_enabled())
 
 
-class DiscordClientCreateScheduledEventTests(TestCase):
+class DiscordClientScheduledEventTests(TestCase):
     def setUp(self):
         self.client = DiscordClient()
 
@@ -130,20 +130,6 @@ class DiscordClientCreateScheduledEventTests(TestCase):
             )
 
         self.assertEqual(mock_req.call_args.kwargs["json"]["description"], "")
-
-
-class DiscordClientModifyScheduledEventTests(TestCase):
-    def setUp(self):
-        self.client = DiscordClient()
-
-    def _mock_request(self, event_id="987654321"):
-        resp = MagicMock()
-        resp.json.return_value = {
-            "id": event_id,
-            "name": "Test Event",
-            "entity_type": 3,
-        }
-        return patch.object(self.client, "_request", return_value=resp)
 
     @override_settings(**DISCORD_SETTINGS)
     def test_sends_patch_to_scoped_event_url(self):

--- a/home/tests/test_discord.py
+++ b/home/tests/test_discord.py
@@ -8,6 +8,7 @@ from datetime import datetime as dt
 from datetime import timezone as dt_timezone
 from unittest.mock import MagicMock, patch
 
+import requests
 from django.test import TestCase, override_settings
 
 from home.factories import EventFactory
@@ -15,6 +16,7 @@ from home.integrations.discord.client import DiscordClient
 from home.integrations.discord.service import (
     _prepare_fields,
     discord_enabled,
+    update_event,
 )
 from home.integrations.zoom.service import ZoomMeeting
 from home.tasks.sync_event import sync_event
@@ -130,6 +132,61 @@ class DiscordClientCreateScheduledEventTests(TestCase):
         self.assertEqual(mock_req.call_args.kwargs["json"]["description"], "")
 
 
+class DiscordClientModifyScheduledEventTests(TestCase):
+    def setUp(self):
+        self.client = DiscordClient()
+
+    def _mock_request(self, event_id="987654321"):
+        resp = MagicMock()
+        resp.json.return_value = {
+            "id": event_id,
+            "name": "Test Event",
+            "entity_type": 3,
+        }
+        return patch.object(self.client, "_request", return_value=resp)
+
+    @override_settings(**DISCORD_SETTINGS)
+    def test_sends_patch_to_scoped_event_url(self):
+        with self._mock_request() as mock_req:
+            self.client.modify_scheduled_event(
+                guild_id="123",
+                event_id="event-1",
+                payload={"name": "Renamed"},
+            )
+
+        self.assertEqual(
+            mock_req.call_args.args,
+            ("PATCH", "/guilds/123/scheduled-events/event-1"),
+        )
+
+    @override_settings(**DISCORD_SETTINGS)
+    def test_forwards_payload_unchanged(self):
+        payload = {
+            "name": "Renamed",
+            "entity_metadata": {"location": "https://zoom.us/j/999"},
+        }
+
+        with self._mock_request() as mock_req:
+            self.client.modify_scheduled_event(
+                guild_id="123",
+                event_id="event-1",
+                payload=payload,
+            )
+
+        self.assertEqual(mock_req.call_args.kwargs["json"], payload)
+
+    @override_settings(**DISCORD_SETTINGS)
+    def test_returns_updated_event_json(self):
+        with self._mock_request(event_id="event-1") as mock_req:
+            result = self.client.modify_scheduled_event(
+                guild_id="123",
+                event_id="event-1",
+                payload={"name": "Renamed"},
+            )
+
+        self.assertEqual(result, mock_req.return_value.json.return_value)
+
+
 class DiscordClientRequestTests(TestCase):
     def setUp(self):
         self.client = DiscordClient()
@@ -156,6 +213,21 @@ class DiscordClientRequestTests(TestCase):
             with self.assertLogs("home.integrations.discord.client", level="ERROR"):
                 with self.assertRaises(Exception):
                     self.client._request("GET", "/foo")
+
+    @override_settings(**DISCORD_SETTINGS)
+    def test_logs_response_body_and_reraises_on_http_error(self):
+        resp = MagicMock(status_code=500)
+        resp.text = "boom"
+        resp.raise_for_status.side_effect = requests.HTTPError(response=resp)
+
+        with patch.object(self.client.session, "request", return_value=resp):
+            with self.assertLogs(
+                "home.integrations.discord.client", level="ERROR"
+            ) as logs:
+                with self.assertRaises(requests.HTTPError):
+                    self.client._request("GET", "/foo")
+
+        self.assertIn("boom", "\n".join(logs.output))
 
 
 class PrepareFieldsTests(TestCase):
@@ -185,6 +257,51 @@ class PrepareFieldsTests(TestCase):
         event = self._event(zoom_link="https://zoom.us/j/" + "z" * 100)
         with self.assertRaises(ValueError):
             _prepare_fields(event)
+
+
+class UpdateEventTests(TestCase):
+    """Service-level update_event: the payload sent to Discord mirrors the
+    create path, but as a PATCH targeting the stored discord_event_id."""
+
+    @override_settings(**DISCORD_SETTINGS)
+    @patch("home.integrations.discord.service.discord_client")
+    def test_builds_expected_modify_payload(self, mock_client):
+        event = EventFactory.build(
+            title="My Event",
+            description="A description",
+            zoom_link="https://zoom.us/j/123",
+            discord_event_id="discord-456",
+            start_time=dt(2026, 6, 1, 14, 0, tzinfo=UTC),
+        )
+
+        update_event(event)
+
+        mock_client.modify_scheduled_event.assert_called_once_with(
+            guild_id="123456789",
+            event_id="discord-456",
+            payload={
+                "name": "My Event",
+                "description": "A description",
+                "entity_metadata": {"location": "https://zoom.us/j/123"},
+                "scheduled_start_time": "2026-06-01T14:00:00+00:00",
+                "scheduled_end_time": "2026-06-01T15:00:00+00:00",
+            },
+        )
+
+    @override_settings(**DISCORD_SETTINGS)
+    @patch("home.integrations.discord.service.discord_client")
+    def test_raises_on_over_long_zoom_link_without_calling_discord(self, mock_client):
+        event = EventFactory.build(
+            title="My Event",
+            zoom_link="https://zoom.us/j/" + "z" * 100,
+            discord_event_id="discord-456",
+            start_time=dt(2026, 6, 1, 14, 0, tzinfo=UTC),
+        )
+
+        with self.assertRaises(ValueError):
+            update_event(event)
+
+        mock_client.modify_scheduled_event.assert_not_called()
 
 
 class SyncEventDiscordTests(TestCase):

--- a/home/tests/test_discord.py
+++ b/home/tests/test_discord.py
@@ -4,15 +4,17 @@ Tests for Discord integration: DiscordClient, the discord service
 (including the combined Zoom-then-Discord run in a single task).
 """
 
+import json
 from datetime import datetime as dt
 from datetime import timezone as dt_timezone
 from unittest.mock import MagicMock, patch
 
 import requests
+import responses as rsps
 from django.test import TestCase, override_settings
 
 from home.factories import EventFactory
-from home.integrations.discord.client import DiscordClient
+from home.integrations.discord.client import BASE_URL, DiscordClient
 from home.integrations.discord.service import (
     _prepare_fields,
     discord_enabled,
@@ -247,11 +249,15 @@ class PrepareFieldsTests(TestCase):
 
 class UpdateEventTests(TestCase):
     """Service-level update_event: the payload sent to Discord mirrors the
-    create path, but as a PATCH targeting the stored discord_event_id."""
+    create path, but as a PATCH targeting the stored discord_event_id.
+
+    Discord is stubbed at the HTTP layer so the real client, payload
+    serialization, and URL construction are exercised end to end.
+    """
 
     @override_settings(**DISCORD_SETTINGS)
-    @patch("home.integrations.discord.service.discord_client")
-    def test_builds_expected_modify_payload(self, mock_client):
+    @rsps.activate
+    def test_builds_expected_modify_payload(self):
         event = EventFactory.build(
             title="My Event",
             description="A description",
@@ -259,13 +265,17 @@ class UpdateEventTests(TestCase):
             discord_event_id="discord-456",
             start_time=dt(2026, 6, 1, 14, 0, tzinfo=UTC),
         )
+        rsps.add(
+            rsps.PATCH,
+            f"{BASE_URL}/guilds/123456789/scheduled-events/discord-456",
+            json={"id": "discord-456"},
+        )
 
         update_event(event)
 
-        mock_client.modify_scheduled_event.assert_called_once_with(
-            guild_id="123456789",
-            event_id="discord-456",
-            payload={
+        self.assertEqual(
+            json.loads(rsps.calls[0].request.body),
+            {
                 "name": "My Event",
                 "description": "A description",
                 "entity_metadata": {"location": "https://zoom.us/j/123"},
@@ -275,8 +285,8 @@ class UpdateEventTests(TestCase):
         )
 
     @override_settings(**DISCORD_SETTINGS)
-    @patch("home.integrations.discord.service.discord_client")
-    def test_raises_on_over_long_zoom_link_without_calling_discord(self, mock_client):
+    @rsps.activate
+    def test_raises_on_over_long_zoom_link_without_calling_discord(self):
         event = EventFactory.build(
             title="My Event",
             zoom_link="https://zoom.us/j/" + "z" * 100,
@@ -287,7 +297,7 @@ class UpdateEventTests(TestCase):
         with self.assertRaises(ValueError):
             update_event(event)
 
-        mock_client.modify_scheduled_event.assert_not_called()
+        self.assertEqual(len(rsps.calls), 0)
 
 
 class SyncEventDiscordTests(TestCase):


### PR DESCRIPTION
Cover the modify/update flow that mirrors the existing create tests:

- DiscordClient.modify_scheduled_event: PATCH to the scoped guild/scheduled-event URL, payload forwarded unchanged, and the updated event JSON returned.
- DiscordClient._request: logs the response body and re-raises on HTTP error.
- service.update_event: builds the same payload as the create path but as a PATCH targeting the stored discord_event_id, and raises without calling Discord when the Zoom link exceeds the location limit.