### PR TITLE
Remove events links from the front-end navigation and landing page. 

### DIFF
--- a/home/templates/home/home_page.html
+++ b/home/templates/home/home_page.html
@@ -17,17 +17,18 @@ This is used directly by Wagtail. Don't delete it.
 
         <div class="hidden lg:flex gap-6 justify-end">
           <div class="relative inline-block" x-data="{ aboutOpen: false }" @mouseleave="aboutOpen = false">
-            <a class="button-secondary text-white font-bold hover:bg-ds-purple hover:text-white focus-visible:ring-2 focus-visible:ring-ds-purple flex items-center gap-1"
-               href="{% url 'event_list' %}"
-               @mouseenter="aboutOpen = true"
-               @focus="aboutOpen = true"
+            <button type="button"
+                    class="button-secondary text-white font-bold cursor-pointer hover:bg-ds-purple hover:text-white focus-visible:ring-2 focus-visible:ring-ds-purple flex items-center gap-1"
+                    @mouseenter="aboutOpen = true"
+                    @focus="aboutOpen = true"
+                    @click="aboutOpen = !aboutOpen"
             >
               About
               <svg class="w-4 h-4 transition-transform duration-200" :class="aboutOpen ? 'rotate-180' : ''" fill="none"
                    stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/>
               </svg>
-            </a>
+            </button>
 
             <div x-show="aboutOpen"
                  x-cloak
@@ -183,10 +184,10 @@ This is used directly by Wagtail. Don't delete it.
 
         {% if not user.is_authenticated %}
           <a class="button-secondary text-white font-bold hover:bg-ds-purple hover:text-white focus-visible:ring-2"
-             href="{% url "event_list" %}">Login</a>
+             href="{% url "login" %}">Login</a>
 
           <a class="bg-white text-[#202020] text-center py-3 rounded-xl font-bold hover:bg-ds-purple no-underline hover:text-white focus-visible:ring-2"
-             href="{% url "event_list" %}">Sign up</a>
+             href="{% url "signup" %}">Sign up</a>
         {% else %}
           <span role="separator" class="my-1 border-t border-gray-500"></span>
           <a href="{% url 'user_sessions' %}"

--- a/indymeet/templates/includes/nav.html
+++ b/indymeet/templates/includes/nav.html
@@ -14,11 +14,6 @@
                         </a>
                     </li>
                     <li>
-                        <a class="outline-link text-gray-700 transition hover:text-ds-purple cursor-pointer"  href="{% url 'event_list' %}">
-                            {% trans "Events" %}
-                        </a>
-                    </li>
-                    <li>
                         <a class="outline-link text-gray-700 transition hover:text-ds-purple cursor-pointer"  href="{% url 'session_list' %}">
                             {% trans "Sessions" %}
                         </a>
@@ -131,12 +126,6 @@
                         <li class="p-2">
                             <a class="block outline-link text-gray-500 transition hover:text-ds-purple" target="_blank" href="https://github.com/djangonaut-space/program/blob/main/README.md">
                                 {% trans "Program Documentation" %}
-                            </a>
-                        </li>
-
-                        <li class="p-2">
-                            <a class="block outline-link text-gray-500 transition hover:text-ds-purple"  href="{% url 'event_list' %}">
-                                {% trans "Events" %}
                             </a>
                         </li>
 


### PR DESCRIPTION
Fixes #735
Removes the events links from the nav and landing page. Also fixed the mobile Login/Sign up buttons which were pointing at the events page, and turned the About dropdown trigger into a button since it no longer links anywhere. 

