### PR TITLE
Add help text for the session and event admin pages.

### DIFF
--- a/home/templates/admin/home/event/change_form.html
+++ b/home/templates/admin/home/event/change_form.html
@@ -1,0 +1,20 @@
+{% extends "admin/change_form.html" %}
+{% load static %}
+
+{% block extrahead %}
+{{ block.super }}
+<link rel="stylesheet" href="{% static 'css/admin_help.css' %}">
+{% endblock %}
+
+{% block form_top %}
+{{ block.super }}
+<div class="save-notice">
+    <strong>What happens when you save this event:</strong>
+    <ul>
+        <li>A Zoom meeting is created (on first save) or updated (on later saves) to match the event's title, start time, and end time.</li>
+        <li>If the event has a Zoom link, a matching Discord scheduled event is created or updated, using the Zoom link as the event's location.</li>
+        <li>Calendar invite emails are <strong>not</strong> sent automatically &mdash; use the "Send calendar invites to event members" action from the Events list, which only sends once per event.</li>
+        <li>Zoom/Discord sync runs in the background, so the "Zoom synced"/"Discord synced" columns on the Events list may take a moment to update after saving.</li>
+    </ul>
+</div>
+{% endblock %}

--- a/home/templates/admin/home/event/change_list.html
+++ b/home/templates/admin/home/event/change_list.html
@@ -1,0 +1,43 @@
+{% extends "admin/change_list.html" %}
+{% load static %}
+
+{% block extrahead %}
+{{ block.super }}
+<link rel="stylesheet" href="{% static 'css/admin_help.css' %}">
+{% endblock %}
+
+{% block search %}
+<details class="help-block">
+    <summary>Help: actions &amp; columns on this page</summary>
+    <div class="help-block-content">
+        <dl>
+            <dt>Bulk actions (the "Action:" dropdown below the list)</dt>
+            <dd>
+                <ul>
+                    <li><strong>Copy selected event and open as new</strong> <code>[runs immediately]</code> &mdash; requires exactly one selected event; opens the add form pre-filled with that event's data so you can review, edit, and save it as a new event. Nothing is saved until you submit that form.</li>
+                    <li>
+                        <strong>Send calendar invites to event members</strong> <code>[runs immediately]</code> &mdash; queues calendar invite emails for the selected events. Only sends once per event &mdash; skipped for events that already have invites sent. Recipients depend on the event:
+                        <ul>
+                            <li>Session event &mdash; all members of that session who have an email address.</li>
+                            <li>Public event (no session) &mdash; all users opted in to event updates.</li>
+                            <li>Private event (no session) &mdash; no extra recipients; still sends to the event's configured extra emails (e.g. sessions@djangonaut.space).</li>
+                        </ul>
+                    </li>
+                    <li><strong>Retry Zoom/Discord sync</strong> <code>[runs immediately]</code> &mdash; re-attempts the Zoom/Discord sync for selected events that aren't fully synced yet.</li>
+                </ul>
+                None of these actions show a confirmation page first &mdash; choosing them from the dropdown and clicking "Go" runs them right away.
+            </dd>
+
+            <dt>List columns</dt>
+            <dd>
+                <ul>
+                    <li><strong>Calendar invites sent at</strong> &mdash; when calendar invites were emailed to members; blank means none have been sent yet.</li>
+                    <li><strong>Zoom synced at</strong> &mdash; when the Zoom meeting was last created/updated for this event; blank means it hasn't synced yet.</li>
+                    <li><strong>Discord synced at</strong> &mdash; when the Discord scheduled event was last created/updated for this event; blank means it hasn't synced yet.</li>
+                </ul>
+            </dd>
+        </dl>
+    </div>
+</details>
+{{ block.super }}
+{% endblock %}

--- a/home/templates/admin/home/session/change_list.html
+++ b/home/templates/admin/home/session/change_list.html
@@ -1,0 +1,49 @@
+{% extends "admin/change_list.html" %}
+{% load static %}
+
+{% block extrahead %}
+{{ block.super }}
+<link rel="stylesheet" href="{% static 'css/admin_help.css' %}">
+{% endblock %}
+
+{% block search %}
+<details class="help-block">
+    <summary>Help: actions &amp; links on this page</summary>
+    <div class="help-block-content">
+        <dl>
+            <dt>Form Teams</dt>
+            <dd>Opens the team formation tool to assign applicants to teams based on availability overlap.</dd>
+
+            <dt>Collect Stats</dt>
+            <dd>Opens a form to pull GitHub contribution stats for the session's teams.</dd>
+
+            <dt>Email Actions</dt>
+            <dd>
+                <ul>
+                    <li><strong>Send application results</strong> &mdash; opens a confirmation page before emailing applicants their acceptance/rejection/waitlist results.</li>
+                    <li><strong>Send acceptance reminder emails</strong> &mdash; opens a confirmation page before reminding accepted applicants to confirm their spot.</li>
+                    <li><strong>Send team welcome emails</strong> &mdash; opens a confirmation page before emailing newly formed teams their welcome message.</li>
+                </ul>
+            </dd>
+
+            <dt>Discord</dt>
+            <dd>
+                <ul>
+                    <li><strong>Set up Discord</strong> &mdash; opens a confirmation page before creating the session's Discord category, team channels, and roles as a background task.</li>
+                    <li><strong>Tear down Discord</strong> &mdash; opens a confirmation page before archiving the session's Discord channels and roles as a background task.</li>
+                    <li><strong>Team messages</strong> &mdash; shows copy-paste welcome text for each team's Discord channel.</li>
+                </ul>
+            </dd>
+
+            <dt>Bulk actions (the "Action:" dropdown below the list)</dt>
+            <dd>
+                <ul>
+                    <li><strong>Auto-allocate Djangonauts to teams</strong> &mdash; [runs immediately] requires exactly one selected session; runs the allocation algorithm to assign eligible applicants to teams.</li>
+                    <li><strong>Preview rejection/waitlist/team-welcome email</strong> &mdash; sends a preview of the email to your own address only; it does not email applicants.</li>
+                </ul>
+            </dd>
+        </dl>
+    </div>
+</details>
+{{ block.super }}
+{% endblock %}

--- a/indymeet/static/css/admin_help.css
+++ b/indymeet/static/css/admin_help.css
@@ -1,0 +1,66 @@
+/* Admin Help Styles */
+
+/* ============================================
+   Expandable Help Block
+   ============================================ */
+.help-block {
+    border: 1px solid var(--border-color);
+    padding: 1rem;
+    margin-bottom: 1rem;
+    border-radius: 4px;
+}
+
+.help-block summary {
+    cursor: pointer;
+    font-weight: bold;
+}
+
+.help-block[open] summary {
+    margin-bottom: 1rem;
+}
+
+.help-block-content dl {
+    margin: 0;
+}
+
+.help-block-content dt {
+    font-weight: bold;
+    margin-top: 0.75rem;
+}
+
+.help-block-content dt:first-child {
+    margin-top: 0;
+}
+
+.help-block-content dd {
+    margin: 0.15rem 0 0 0;
+}
+
+.help-block-content ul {
+    margin: 0.5rem 0;
+    padding-left: 1.25rem;
+}
+
+.help-block-content code {
+    font-size: 0.8em;
+}
+
+/* ============================================
+   Save Notice
+   ============================================ */
+.save-notice {
+    border: 1px solid var(--border-color);
+    border-left-width: 4px;
+    padding: 0.75rem 1rem;
+    margin-bottom: 1rem;
+    border-radius: 0 4px 4px 0;
+}
+
+.save-notice ul {
+    margin: 0.5rem 0 0 0;
+    padding-left: 1.25rem;
+}
+
+.save-notice li {
+    margin-bottom: 0.25rem;
+}


### PR DESCRIPTION
This adds some help text and context for the custom actions and tools in the admin.

## Add Event page

<img width="1228" height="329" alt="Screenshot 2026-07-29 at 8 57 11 PM" src="https://github.com/user-attachments/assets/3a4f5091-7f74-4a3a-869f-e6eb98d3c3b3" />

## Event list page

<img width="1228" height="609" alt="Screenshot 2026-07-29 at 8 57 23 PM" src="https://github.com/user-attachments/assets/7ec1df80-63a8-4111-bf6c-7d1c3e08a992" />

## Session list page

<img width="1106" height="207" alt="Screenshot 2026-07-29 at 7 38 12 PM" src="https://github.com/user-attachments/assets/d14acc1b-27f9-44ee-95ce-2614876b4835" />