### PR TITLE
EventAdmin: show Zoom/Discord sync status as booleans in list display

### DIFF
--- a/home/admin.py
+++ b/home/admin.py
@@ -157,8 +157,8 @@ class EventAdmin(DescriptiveSearchMixin, admin.ModelAdmin):
         "title",
         "start_time",
         "calendar_invites_sent_at",
-        "zoom_synced_at",
-        "discord_synced_at",
+        "zoom_synced",
+        "discord_synced",
     ]
     readonly_fields = ("zoom_synced_at", "discord_synced_at")
     field_help_text = {
@@ -176,6 +176,16 @@ class EventAdmin(DescriptiveSearchMixin, admin.ModelAdmin):
         if formfield and db_field.name in self.field_help_text:
             formfield.help_text = self.field_help_text[db_field.name]
         return formfield
+
+    @admin.display(description="Zoom synced", boolean=True, ordering="zoom_synced_at")
+    def zoom_synced(self, obj: Event) -> bool:
+        return obj.zoom_synced_at is not None
+
+    @admin.display(
+        description="Discord synced", boolean=True, ordering="discord_synced_at"
+    )
+    def discord_synced(self, obj: Event) -> bool:
+        return obj.discord_synced_at is not None
 
     def save_model(self, request, obj, form, change) -> None:
         """Save the event, then dispatch the Zoom/Discord sync and report back.

--- a/home/templates/admin/home/event/change_list.html
+++ b/home/templates/admin/home/event/change_list.html
@@ -32,8 +32,8 @@
             <dd>
                 <ul>
                     <li><strong>Calendar invites sent at</strong> &mdash; when calendar invites were emailed to members; blank means none have been sent yet.</li>
-                    <li><strong>Zoom synced at</strong> &mdash; when the Zoom meeting was last created/updated for this event; blank means it hasn't synced yet.</li>
-                    <li><strong>Discord synced at</strong> &mdash; when the Discord scheduled event was last created/updated for this event; blank means it hasn't synced yet.</li>
+                    <li><strong>Zoom synced</strong> &mdash; whether a Zoom meeting has been created/updated for this event.</li>
+                    <li><strong>Discord synced</strong> &mdash; whether a Discord scheduled event has been created/updated for this event.</li>
                 </ul>
             </dd>
         </dl>

--- a/home/tests/test_admin_event.py
+++ b/home/tests/test_admin_event.py
@@ -470,3 +470,22 @@ class EventAdminSaveModelTests(TestCase):
         self.assertEqual(len(stored), 1)
         self.assertEqual(stored[0].level, messages.WARNING)
         self.assertEqual(str(stored[0]), "No Zoom configured.")
+
+
+class EventAdminSyncedDisplayTests(TestCase):
+    """Tests for the zoom_synced/discord_synced list_display methods."""
+
+    def setUp(self):
+        self.admin = EventAdmin(Event, AdminSite())
+
+    def test_reflects_synced_at_timestamps(self):
+        """Each method is True only when its *_synced_at timestamp is set."""
+        synced = EventFactory.build(
+            zoom_synced_at=datetime.now(dt_timezone.utc), discord_synced_at=None
+        )
+        unsynced = EventFactory.build(zoom_synced_at=None, discord_synced_at=None)
+
+        self.assertTrue(self.admin.zoom_synced(synced))
+        self.assertFalse(self.admin.discord_synced(synced))
+        self.assertFalse(self.admin.zoom_synced(unsynced))
+        self.assertFalse(self.admin.discord_synced(unsynced))


### PR DESCRIPTION
Closes #839

<img width="1516" height="708" alt="image" src="https://github.com/user-attachments/assets/33c2254a-2db1-43aa-8915-a774d320cbdc" />
