### PR TITLE
Show the extra fields when previewing a session application as organizer

### DIFF
--- a/home/forms.py
+++ b/home/forms.py
@@ -177,7 +177,10 @@ class BaseSurveyForm(forms.Form):
         except ObjectDoesNotExist:
             pass
         else:
-            if app_session.is_accepting_applications():
+            is_organizer_preview = self.user is not None and self.user.has_perm(
+                "home.form_team"
+            )
+            if app_session.is_accepting_applications() or is_organizer_preview:
                 self.session = app_session
 
                 # Add project preference field if session has available projects

--- a/home/tests/test_user_survey_response_form_views.py
+++ b/home/tests/test_user_survey_response_form_views.py
@@ -60,6 +60,8 @@ class CreateUserSurveyResponseFormViewTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertNotContains(response, "will be open on")
         self.assertContains(response, "Submit")
+        # Session-specific fields should also render during the preview.
+        self.assertContains(response, "GitHub Username")
 
     def test_cannot_access_survey_after_application_closes(self):
         """Users should not be able to access the survey form after the application period ends."""


### PR DESCRIPTION
Refs: #854
Follow-up to #855