### PR TITLE
Pass the user's IP address to buttondown when subscribing them.

### DIFF
--- a/accounts/receivers.py
+++ b/accounts/receivers.py
@@ -5,6 +5,7 @@ and for syncing users to the Buttondown newsletter.
 
 from home import constants
 from django.contrib.auth.models import Group
+from django.db import transaction
 from django.db.models.signals import post_delete, post_save
 from django.dispatch import receiver
 
@@ -63,7 +64,9 @@ def sync_buttondown_on_profile_save(
     if not buttondown_enabled() or raw or not instance.email_confirmed:
         return
     ip_address = getattr(instance, "_buttondown_ip_address", None)
-    sync_user_to_buttondown.enqueue(instance.user_id, ip_address=ip_address)
+    transaction.on_commit(
+        lambda: sync_user_to_buttondown.enqueue(instance.user_id, ip_address=ip_address)
+    )
 
 
 @receiver(

--- a/accounts/receivers.py
+++ b/accounts/receivers.py
@@ -55,10 +55,15 @@ def sync_buttondown_on_profile_save(
 
     Fires on every save where email_confirmed is True, keeping tags and
     subscription status in sync with any profile changes.
+
+    If the view that triggered this save set `_buttondown_ip_address` on the
+    instance (e.g. account activation), it's forwarded to the sync task so a
+    newly-created Buttondown subscriber records the originating request's IP.
     """
     if not buttondown_enabled() or raw or not instance.email_confirmed:
         return
-    sync_user_to_buttondown.enqueue(instance.user_id)
+    ip_address = getattr(instance, "_buttondown_ip_address", None)
+    sync_user_to_buttondown.enqueue(instance.user_id, ip_address=ip_address)
 
 
 @receiver(

--- a/accounts/tests/test_activate_view.py
+++ b/accounts/tests/test_activate_view.py
@@ -1,11 +1,18 @@
+import json
+
+import responses as rsps
 from django.test import Client
 from django.test import TestCase
+from django.test import override_settings
 from django.urls import reverse
 from django.utils.encoding import force_bytes
 from django.utils.http import urlsafe_base64_encode
 
 from accounts.factories import UserFactory
 from accounts.tokens import account_activation_token
+
+BD_SETTINGS = {"BUTTONDOWN_API_KEY": "test-api-key"}
+_BASE_URL = "https://api.buttondown.email/v1"
 
 
 class ActivateViewTests(TestCase):
@@ -56,3 +63,27 @@ class ActivateViewTests(TestCase):
         self.assertRedirects(response, reverse("profile"))
         self.user.profile.refresh_from_db()
         self.assertTrue(self.user.profile.email_confirmed)
+
+    @override_settings(**BD_SETTINGS)
+    @rsps.activate
+    def test_activate_email_forwards_client_ip_to_buttondown(self):
+        rsps.add(rsps.GET, f"{_BASE_URL}/subscribers/{self.user.email}", status=404)
+        rsps.add(
+            rsps.POST,
+            f"{_BASE_URL}/subscribers",
+            json={"id": "new-uuid"},
+            status=201,
+        )
+        activate_url = reverse(
+            "activate_account",
+            kwargs={
+                "uidb64": urlsafe_base64_encode(force_bytes(self.user.pk)),
+                "token": account_activation_token.make_token(self.user),
+            },
+        )
+
+        self.client.get(activate_url, REMOTE_ADDR="203.0.113.5")
+
+        create_call = next(call for call in rsps.calls if call.request.method == "POST")
+        body = json.loads(create_call.request.body)
+        self.assertEqual(body["ip_address"], "203.0.113.5")

--- a/accounts/tests/test_activate_view.py
+++ b/accounts/tests/test_activate_view.py
@@ -10,8 +10,8 @@ from django.utils.http import urlsafe_base64_encode
 
 from accounts.factories import UserFactory
 from accounts.tokens import account_activation_token
+from conftest import BD_SETTINGS
 
-BD_SETTINGS = {"BUTTONDOWN_API_KEY": "test-api-key"}
 _BASE_URL = "https://api.buttondown.email/v1"
 
 
@@ -82,7 +82,8 @@ class ActivateViewTests(TestCase):
             },
         )
 
-        self.client.get(activate_url, REMOTE_ADDR="203.0.113.5")
+        with self.captureOnCommitCallbacks(execute=True):
+            self.client.get(activate_url, REMOTE_ADDR="203.0.113.5")
 
         create_call = next(call for call in rsps.calls if call.request.method == "POST")
         body = json.loads(create_call.request.body)

--- a/accounts/tests/test_buttondown_signals.py
+++ b/accounts/tests/test_buttondown_signals.py
@@ -38,7 +38,8 @@ class ButtondownSignalTests(TestCase):
 
         user.profile.email_confirmed = True
         user.profile.bio = "updated"
-        user.profile.save()
+        with self.captureOnCommitCallbacks(execute=True):
+            user.profile.save()
 
         self.assertEqual(len(rsps.calls), 1)
         self.assertEqual(rsps.calls[0].request.method, "PATCH")
@@ -57,7 +58,8 @@ class ButtondownSignalTests(TestCase):
 
         user.profile.email_confirmed = True
         user.profile.bio = "updated"
-        user.profile.save()
+        with self.captureOnCommitCallbacks(execute=True):
+            user.profile.save()
 
         self.assertGreaterEqual(len(rsps.calls), 1)
 
@@ -75,7 +77,8 @@ class ButtondownSignalTests(TestCase):
 
         user.profile.email_confirmed = True
         user.profile.receiving_newsletter = True
-        user.profile.save()
+        with self.captureOnCommitCallbacks(execute=True):
+            user.profile.save()
 
         self.assertGreaterEqual(len(rsps.calls), 1)
 
@@ -93,7 +96,8 @@ class ButtondownSignalTests(TestCase):
 
         user.profile.email_confirmed = True
         user.profile._buttondown_ip_address = "203.0.113.5"
-        user.profile.save()
+        with self.captureOnCommitCallbacks(execute=True):
+            user.profile.save()
 
         create_call = next(call for call in rsps.calls if call.request.method == "POST")
         body = json.loads(create_call.request.body)

--- a/accounts/tests/test_buttondown_signals.py
+++ b/accounts/tests/test_buttondown_signals.py
@@ -1,5 +1,7 @@
 """Tests for the Buttondown signal handler in accounts/receivers.py."""
 
+import json
+
 import responses as rsps
 from django.contrib.auth import get_user_model
 from django.test import TestCase, override_settings
@@ -76,6 +78,26 @@ class ButtondownSignalTests(TestCase):
         user.profile.save()
 
         self.assertGreaterEqual(len(rsps.calls), 1)
+
+    @override_settings(**BD_SETTINGS)
+    @rsps.activate
+    def test_profile_save_forwards_ip_address_on_new_subscriber(self):
+        user = UserFactory.create()
+        rsps.add(rsps.GET, f"{_BASE_URL}/subscribers/{user.email}", status=404)
+        rsps.add(
+            rsps.POST,
+            f"{_BASE_URL}/subscribers",
+            json={"id": "new-uuid"},
+            status=201,
+        )
+
+        user.profile.email_confirmed = True
+        user.profile._buttondown_ip_address = "203.0.113.5"
+        user.profile.save()
+
+        create_call = next(call for call in rsps.calls if call.request.method == "POST")
+        body = json.loads(create_call.request.body)
+        self.assertEqual(body["ip_address"], "203.0.113.5")
 
     @override_settings(**BD_SETTINGS)
     @rsps.activate

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -29,6 +29,7 @@ from django.views.generic.edit import UpdateView
 from home import constants
 from home.email import send
 from home.models import Testimonial
+from home.utils import get_client_ip
 
 from .forms import CustomUserChangeForm
 from .forms import CustomUserCreationForm
@@ -77,6 +78,7 @@ class ActivateAccountView(View):
             user = None
         if user is not None and account_activation_token.check_token(user, token):
             user.profile.email_confirmed = True
+            user.profile._buttondown_ip_address = get_client_ip(request)
             user.profile.save()
             login(request, user)
             return redirect("profile")

--- a/conftest.py
+++ b/conftest.py
@@ -1,5 +1,7 @@
 import pytest
 
+BD_SETTINGS = {"BUTTONDOWN_API_KEY": "test-api-key"}
+
 
 @pytest.fixture(autouse=True)
 def disable_zoom_credentials(settings):

--- a/docs/integrations/buttondown.md
+++ b/docs/integrations/buttondown.md
@@ -60,6 +60,6 @@ Ongoing syncs are handled automatically on every user profile save.
 
 ## IP Address on Subscription
 
-Buttondown's subscriber-creation endpoint accepts an `ip_address` field, used for location detection and legitimacy validation. Since most syncs are triggered by `post_save` signals with no HTTP request in scope, the IP is only captured where a request is actually available: `ActivateAccountView` (`accounts/views.py`), the point at which most users first get synced to Buttondown.
+Buttondown's subscriber-creation endpoint accepts an `ip_address` field, used for location detection and legitimacy validation. When a user confirms their account (activates their account), the view stashes the IP address as a transient, non-persisted attribute (`_buttondown_ip_address`) on the `UserProfile` instance before saving. The `post_save` signal handle queues a task to sync the buttondown subscription.
 
 The flow: the view reads the client IP via `get_client_ip()` (`home/utils.py`) and stashes it as a transient, non-persisted attribute (`_buttondown_ip_address`) on the `UserProfile` instance before saving. The `post_save` signal handler (`accounts/receivers.py`) reads that attribute off the instance and forwards it through `sync_user_to_buttondown.enqueue()` -> `ButtondownService.sync_user()` -> `ButtondownClient.create_subscriber()`. It's only ever sent when a *new* Buttondown subscriber is being created — existing subscribers are updated via PATCH, which doesn't use this field. The IP is never persisted to our own database.

--- a/docs/integrations/buttondown.md
+++ b/docs/integrations/buttondown.md
@@ -57,3 +57,9 @@ uv run python manage.py sync_buttondown
 ```
 
 Ongoing syncs are handled automatically on every user profile save.
+
+## IP Address on Subscription
+
+Buttondown's subscriber-creation endpoint accepts an `ip_address` field, used for location detection and legitimacy validation. Since most syncs are triggered by `post_save` signals with no HTTP request in scope, the IP is only captured where a request is actually available: `ActivateAccountView` (`accounts/views.py`), the point at which most users first get synced to Buttondown.
+
+The flow: the view reads the client IP via `get_client_ip()` (`home/utils.py`) and stashes it as a transient, non-persisted attribute (`_buttondown_ip_address`) on the `UserProfile` instance before saving. The `post_save` signal handler (`accounts/receivers.py`) reads that attribute off the instance and forwards it through `sync_user_to_buttondown.enqueue()` -> `ButtondownService.sync_user()` -> `ButtondownClient.create_subscriber()`. It's only ever sent when a *new* Buttondown subscriber is being created — existing subscribers are updated via PATCH, which doesn't use this field. The IP is never persisted to our own database.

--- a/home/integrations/buttondown/client.py
+++ b/home/integrations/buttondown/client.py
@@ -63,17 +63,18 @@ class ButtondownClient:
             raise
         return response.json()
 
-    def create_subscriber(self, email: str, tags: list[str]) -> dict:
+    def create_subscriber(
+        self, email: str, tags: list[str], ip_address: str | None = None
+    ) -> dict:
         """
         Create a new subscriber.
 
         Returns the created subscriber dict (including 'id' UUID).
         """
-        response = self._request(
-            "POST",
-            "/subscribers",
-            json={"email_address": email, "tags": tags, "type": "regular"},
-        )
+        payload = {"email_address": email, "tags": tags, "type": "regular"}
+        if ip_address:
+            payload["ip_address"] = ip_address
+        response = self._request("POST", "/subscribers", json=payload)
         return response.json()
 
     def patch_subscriber(self, subscriber_id: str, payload: dict) -> dict:

--- a/home/integrations/buttondown/service.py
+++ b/home/integrations/buttondown/service.py
@@ -94,7 +94,7 @@ class ButtondownService:
     def __init__(self) -> None:
         self.client = ButtondownClient()
 
-    def sync_user(self, user) -> None:
+    def sync_user(self, user, ip_address: str | None = None) -> None:
         """
         Sync a single user to Buttondown.
 
@@ -102,6 +102,9 @@ class ButtondownService:
         known. If not (new user or account without an ID), it looks up the subscriber
         by email and links them, or creates a new one. If the ID is known, it updates
         tags or subscription status.
+
+        ip_address is only used if a new subscriber ends up being created, matching
+        Buttondown's use of the field for the originating subscription request.
         """
         try:
             bd_account = user.buttondown_account
@@ -132,14 +135,19 @@ class ButtondownService:
                         raise
 
             if not subscriber_id:
-                self._resolve_and_link(user, bd_account)
+                self._resolve_and_link(user, bd_account, ip_address=ip_address)
                 return
 
             bd_account.save()  # Touch last_updated via auto_now
         except Exception:
             logger.exception("Failed to sync user %s to Buttondown", user.pk)
 
-    def _resolve_and_link(self, user, bd_account: "ButtondownAccount | None") -> None:
+    def _resolve_and_link(
+        self,
+        user,
+        bd_account: "ButtondownAccount | None",
+        ip_address: str | None = None,
+    ) -> None:
         """
         Resolve a subscriber ID by looking up the user's email, then link or create.
 
@@ -162,7 +170,9 @@ class ButtondownService:
         else:
             tags = get_tags_for_user(user)
             tags.insert(0, "website")
-            data = self.client.create_subscriber(user.email, tags)
+            data = self.client.create_subscriber(
+                user.email, tags, ip_address=ip_address
+            )
             subscriber_id = data["id"]
             ButtondownAccount.objects.update_or_create(
                 user=user, defaults={"buttondown_identifier": subscriber_id}

--- a/home/tasks/sync_buttondown.py
+++ b/home/tasks/sync_buttondown.py
@@ -11,11 +11,13 @@ User = get_user_model()
 
 
 @task()
-def sync_user_to_buttondown(user_id: int) -> None:
+def sync_user_to_buttondown(user_id: int, ip_address: str | None = None) -> None:
     """
     Sync a single user's newsletter subscription state to Buttondown.
 
     Safely handles missing credentials, deleted users, and API failures.
+    ip_address, if provided, is forwarded to Buttondown only if a new
+    subscriber ends up being created.
     """
     if not buttondown_enabled():
         logger.warning(
@@ -31,4 +33,4 @@ def sync_user_to_buttondown(user_id: int) -> None:
         logger.warning("User %s no longer exists; skipping Buttondown sync", user_id)
         return
 
-    buttondown_service.sync_user(user)
+    buttondown_service.sync_user(user, ip_address=ip_address)

--- a/home/tests/test_buttondown.py
+++ b/home/tests/test_buttondown.py
@@ -121,6 +121,23 @@ class ButtondownClientTests(TestCase):
 
     @override_settings(**BD_SETTINGS)
     @rsps.activate
+    def test_create_subscriber_includes_ip_address_when_given(self):
+        rsps.add(
+            rsps.POST,
+            f"{_BASE_URL}/subscribers",
+            json={"id": "new-uuid", "email": "new@example.com"},
+            status=201,
+        )
+
+        self.bd_client.create_subscriber(
+            "new@example.com", ["website"], ip_address="203.0.113.5"
+        )
+
+        body = json.loads(rsps.calls[0].request.body)
+        self.assertEqual(body["ip_address"], "203.0.113.5")
+
+    @override_settings(**BD_SETTINGS)
+    @rsps.activate
     def test_patch_subscriber(self):
         payload = {"tags": ["Admin"], "type": "regular"}
         rsps.add(
@@ -375,6 +392,39 @@ class ButtondownServiceFirstSyncTests(TestCase):
 
         tags_arg = mock_create.call_args.args[1]
         self.assertIn("website", tags_arg)
+
+    @override_settings(**BD_SETTINGS)
+    def test_first_sync_forwards_ip_address_on_new_subscriber(self):
+        with (
+            patch.object(
+                buttondown_service.client,
+                "get_subscriber_by_email",
+                return_value=None,
+            ),
+            patch.object(
+                buttondown_service.client,
+                "create_subscriber",
+                return_value={"id": "bd-uuid-new"},
+            ) as mock_create,
+        ):
+            buttondown_service.sync_user(self.user, ip_address="203.0.113.5")
+
+        self.assertEqual(mock_create.call_args.kwargs["ip_address"], "203.0.113.5")
+
+    @override_settings(**BD_SETTINGS)
+    def test_first_sync_links_existing_does_not_forward_ip_address(self):
+        existing = {"id": "bd-uuid-existing"}
+        with (
+            patch.object(
+                buttondown_service.client,
+                "get_subscriber_by_email",
+                return_value=existing,
+            ),
+            patch.object(buttondown_service.client, "patch_subscriber") as mock_patch,
+        ):
+            buttondown_service.sync_user(self.user, ip_address="203.0.113.5")
+
+        self.assertNotIn("ip_address", mock_patch.call_args.args[1])
 
     @override_settings(**BD_SETTINGS)
     def test_first_sync_new_subscriber_does_not_set_receiving_newsletter(self):
@@ -633,3 +683,11 @@ class SyncUserToButtondownTaskTests(TestCase):
 
         mock_sync.assert_called_once()
         self.assertEqual(mock_sync.call_args.args[0].pk, user.pk)
+
+    @override_settings(**BD_SETTINGS)
+    def test_forwards_ip_address_to_service(self):
+        user = UserFactory.create()
+        with patch.object(buttondown_service, "sync_user") as mock_sync:
+            sync_user_to_buttondown.call(user_id=user.pk, ip_address="203.0.113.5")
+
+        self.assertEqual(mock_sync.call_args.kwargs["ip_address"], "203.0.113.5")

--- a/home/tests/test_utils.py
+++ b/home/tests/test_utils.py
@@ -1,0 +1,25 @@
+from django.test import RequestFactory, TestCase
+
+from home.utils import get_client_ip
+
+
+class GetClientIpTests(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+
+    def test_uses_remote_addr_when_no_forwarded_header(self):
+        request = self.factory.get("/", REMOTE_ADDR="198.51.100.1")
+        self.assertEqual(get_client_ip(request), "198.51.100.1")
+
+    def test_prefers_leftmost_forwarded_for_address(self):
+        request = self.factory.get(
+            "/",
+            REMOTE_ADDR="10.0.0.1",
+            HTTP_X_FORWARDED_FOR="203.0.113.5, 10.0.0.1",
+        )
+        self.assertEqual(get_client_ip(request), "203.0.113.5")
+
+    def test_returns_none_when_neither_header_present(self):
+        request = self.factory.get("/")
+        del request.META["REMOTE_ADDR"]
+        self.assertIsNone(get_client_ip(request))

--- a/home/utils.py
+++ b/home/utils.py
@@ -1,4 +1,18 @@
+from django.http import HttpRequest
 from django.utils.safestring import mark_safe
+
+
+def get_client_ip(request: HttpRequest) -> str | None:
+    """
+    Best-effort extraction of the client's IP address from a request.
+
+    Prefers the leftmost address in X-Forwarded-For, since the app runs
+    behind a reverse proxy in production, falling back to REMOTE_ADDR.
+    """
+    forwarded_for = request.headers.get("x-forwarded-for")
+    if forwarded_for:
+        return forwarded_for.split(",")[0].strip()
+    return request.META.get("REMOTE_ADDR")
 
 
 def create_star(active_star: int, num_stars: int = 5, id_element: str = "") -> str:


### PR DESCRIPTION
Do not store the user's IP address.

Fixes #867 