### PR TITLE
Show the applicant's project preferences in admin and CSVs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ This is the web application for the Djangonaut Space mentoring program. The plat
 
 1. Clone the repo
    ```sh
-   git clone https://github.com/dawnwages/wagtail-indymeet.git
+   git clone https://github.com/djangonaut-space/wagtail-indymeet.git
    ```
 
 2. Have docker running and then run:

--- a/home/admin.py
+++ b/home/admin.py
@@ -5,7 +5,7 @@ from django.contrib import admin, messages
 from django.contrib.admin import helpers
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group
-from django.db.models import Count, Exists, F, Max, OuterRef, TextField
+from django.db.models import Count, Exists, F, Max, OuterRef, Prefetch, TextField
 from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, redirect, render
 from django.template.loader import render_to_string
@@ -41,6 +41,7 @@ from .models import (
     Announcement,
     Event,
     Project,
+    ProjectPreference,
     Question,
     ResourceLink,
     Session,
@@ -1655,6 +1656,7 @@ class UserSurveyResponseAdmin(DescriptiveSearchMixin, admin.ModelAdmin):
     list_display = [
         "survey_name",
         "user_email",
+        "project_preferences",
         "created_at",
     ]
     list_filter = [
@@ -1679,6 +1681,14 @@ class UserSurveyResponseAdmin(DescriptiveSearchMixin, admin.ModelAdmin):
                 annotated_survey_name=F("survey__name"),
                 annotated_user_email=F("user__email"),
             )
+            .select_related("survey__application_session")
+            .prefetch_related(
+                Prefetch(
+                    "user__project_preferences",
+                    queryset=ProjectPreference.objects.select_related("project"),
+                    to_attr="prefetched_project_preferences",
+                )
+            )
             .for_admin_site(request.user)
         )
 
@@ -1687,6 +1697,19 @@ class UserSurveyResponseAdmin(DescriptiveSearchMixin, admin.ModelAdmin):
 
     def user_email(self, obj):
         return obj.annotated_user_email
+
+    @admin.display(description="Project Preferences")
+    def project_preferences(self, obj):
+        session = getattr(obj.survey, "application_session", None)
+        if not session:
+            return ""
+        preferences = [
+            preference.project.name
+            for preference in obj.user.prefetched_project_preferences
+            if preference.session_id == session.id
+        ]
+        # No ProjectPreference rows means the user is okay with any project.
+        return ", ".join(preferences) if preferences else "Any project"
 
     @admin.action(description="Re-evaluate tutorial submission")
     def evaluate_tutorial_submission_action(self, request, queryset):

--- a/home/forms.py
+++ b/home/forms.py
@@ -415,6 +415,54 @@ class SurveyCSVExportForm(forms.Form):
         else:
             return self.generate_full_csv(survey)
 
+    def _get_project_preferences_by_user(
+        self, survey: Survey
+    ) -> tuple[list[tuple[int, str]], dict[int, set[int]]]:
+        """
+        Get each user's project preferences for the session tied to this survey.
+
+        Returns:
+            A tuple of:
+            - the session's available projects, as (project id, project name)
+              pairs ordered by project name
+            - a mapping of user id to the set of project ids they're interested in
+        """
+        session = getattr(survey, "application_session", None)
+        if not session:
+            return [], {}
+
+        ordered_projects = list(
+            session.available_projects.order_by("name").values_list("id", "name")
+        )
+
+        project_ids_by_user: dict[int, set[int]] = {}
+        for preference in ProjectPreference.objects.for_session(session):
+            project_ids_by_user.setdefault(preference.user_id, set()).add(
+                preference.project_id
+            )
+        return ordered_projects, project_ids_by_user
+
+    def _project_preference_row_values(
+        self,
+        user_id: int,
+        ordered_projects: list[tuple[int, str]],
+        project_ids_by_user: dict[int, set[int]],
+    ) -> list[str]:
+        """
+        Build one "Yes"/"" cell per project for a user's preference row.
+
+        A user with no ProjectPreference rows for the session hasn't opted out
+        of every project - per ProjectPreference's model docs, they're okay
+        with any project - so every column is marked "Yes" in that case.
+        """
+        user_project_ids = project_ids_by_user.get(user_id)
+        if user_project_ids is None:
+            return ["Yes"] * len(ordered_projects)
+        return [
+            "Yes" if project_id in user_project_ids else ""
+            for project_id, _ in ordered_projects
+        ]
+
     def generate_full_csv(self, survey: Survey) -> HttpResponse:
         """Generate CSV file with survey responses and scorer columns"""
         scorer_names = self.cleaned_data.get("scorer_names", [])
@@ -430,6 +478,11 @@ class SurveyCSVExportForm(forms.Form):
         # Get all questions for this survey
         questions = survey.questions.all().order_by("ordering")
 
+        # Get project preferences by user for this survey's session, if any
+        ordered_projects, project_ids_by_user = self._get_project_preferences_by_user(
+            survey
+        )
+
         # Create the HTTP response with CSV headers (UTF-8 encoded)
         response = HttpResponse(content_type="text/csv; charset=utf-8")
         response["Content-Disposition"] = (
@@ -444,6 +497,8 @@ class SurveyCSVExportForm(forms.Form):
         header = ["Response ID", "Submitter Name"]
         # Add question labels as columns
         header.extend([q.label for q in questions])
+        # Add one column per preferred project, marking each user's interest in it
+        header.extend(project_name for _, project_name in ordered_projects)
         # Add Tutorial Result column
         header.append("Tutorial Result")
         # Add scorer columns
@@ -470,6 +525,13 @@ class SurveyCSVExportForm(forms.Form):
             # Add question responses in order
             for question in questions:
                 row.append(question_responses.get(question.id, ""))
+
+            # Mark interest in each preferred project
+            row.extend(
+                self._project_preference_row_values(
+                    response_obj.user_id, ordered_projects, project_ids_by_user
+                )
+            )
 
             # Add Tutorial Result column
             evaluation = getattr(response_obj, "tutorial_evaluation", None)
@@ -508,6 +570,11 @@ class SurveyCSVExportForm(forms.Form):
             "ordering"
         )
 
+        # Get project preferences by user for this survey's session, if any
+        ordered_projects, project_ids_by_user = self._get_project_preferences_by_user(
+            survey
+        )
+
         # Create the HTTP response with CSV headers (UTF-8 encoded)
         response = HttpResponse(content_type="text/csv; charset=utf-8")
         response["Content-Disposition"] = (
@@ -520,6 +587,8 @@ class SurveyCSVExportForm(forms.Form):
         header = ["Response ID"]
         for question in questions:
             header.extend([question.label, f"{question.label} Score"])
+        # Add one column per preferred project, marking each user's interest in it
+        header.extend(project_name for _, project_name in ordered_projects)
         writer.writerow(header)
 
         # Write data rows
@@ -532,6 +601,14 @@ class SurveyCSVExportForm(forms.Form):
             for question in questions:
                 # Add the response and an empty cell for the score.
                 row.extend([response_map.get(question.id, ""), ""])
+
+            # Mark interest in each preferred project
+            row.extend(
+                self._project_preference_row_values(
+                    response_obj.user_id, ordered_projects, project_ids_by_user
+                )
+            )
+
             writer.writerow(row)
 
         return response

--- a/home/tests/test_admin_user_survey_response_display.py
+++ b/home/tests/test_admin_user_survey_response_display.py
@@ -1,7 +1,7 @@
 """Tests for UserSurveyResponseAdmin list display columns."""
 
 from django.contrib.admin.sites import AdminSite
-from django.test import TestCase
+from django.test import RequestFactory, TestCase
 
 from accounts.factories import UserFactory
 from home.admin import UserSurveyResponseAdmin
@@ -19,7 +19,20 @@ class UserSurveyResponseAdminProjectPreferencesTests(TestCase):
     """Tests for the project_preferences admin display method."""
 
     def setUp(self):
+        self.factory = RequestFactory()
         self.admin = UserSurveyResponseAdmin(UserSurveyResponse, AdminSite())
+        self.superuser = UserFactory.create(
+            email="admin@example.com",
+            first_name="Admin",
+            last_name="User",
+            is_staff=True,
+            is_superuser=True,
+        )
+
+    def _get_request(self):
+        request = self.factory.get("/admin/home/usersurveyresponse/")
+        request.user = self.superuser
+        return request
 
     def test_shows_preferences_in_selection_order(self):
         """The column lists a respondent's chosen projects, comma separated."""
@@ -33,7 +46,7 @@ class UserSurveyResponseAdminProjectPreferencesTests(TestCase):
         ProjectPreferenceFactory.create(user=user, session=session, project=project_a)
         ProjectPreferenceFactory.create(user=user, session=session, project=project_b)
 
-        obj = self.admin.get_queryset(self._request()).get(pk=response.pk)
+        obj = self.admin.get_queryset(self._get_request()).get(pk=response.pk)
         self.assertEqual(self.admin.project_preferences(obj), "Project A, Project B")
 
     def test_shows_any_project_when_no_preferences(self):
@@ -42,7 +55,7 @@ class UserSurveyResponseAdminProjectPreferencesTests(TestCase):
         SessionFactory.create(application_survey=survey)
         response = UserSurveyResponseFactory(survey=survey)
 
-        obj = self.admin.get_queryset(self._request()).get(pk=response.pk)
+        obj = self.admin.get_queryset(self._get_request()).get(pk=response.pk)
         self.assertEqual(self.admin.project_preferences(obj), "Any project")
 
     def test_blank_when_survey_has_no_session(self):
@@ -50,13 +63,5 @@ class UserSurveyResponseAdminProjectPreferencesTests(TestCase):
         survey = SurveyFactory(session=None)
         response = UserSurveyResponseFactory(survey=survey)
 
-        obj = self.admin.get_queryset(self._request()).get(pk=response.pk)
+        obj = self.admin.get_queryset(self._get_request()).get(pk=response.pk)
         self.assertEqual(self.admin.project_preferences(obj), "")
-
-    def _request(self):
-        superuser = UserFactory.create(is_staff=True, is_superuser=True)
-
-        class FakeRequest:
-            user = superuser
-
-        return FakeRequest()

--- a/home/tests/test_admin_user_survey_response_display.py
+++ b/home/tests/test_admin_user_survey_response_display.py
@@ -1,0 +1,62 @@
+"""Tests for UserSurveyResponseAdmin list display columns."""
+
+from django.contrib.admin.sites import AdminSite
+from django.test import TestCase
+
+from accounts.factories import UserFactory
+from home.admin import UserSurveyResponseAdmin
+from home.factories import (
+    ProjectFactory,
+    ProjectPreferenceFactory,
+    SessionFactory,
+    SurveyFactory,
+    UserSurveyResponseFactory,
+)
+from home.models import UserSurveyResponse
+
+
+class UserSurveyResponseAdminProjectPreferencesTests(TestCase):
+    """Tests for the project_preferences admin display method."""
+
+    def setUp(self):
+        self.admin = UserSurveyResponseAdmin(UserSurveyResponse, AdminSite())
+
+    def test_shows_preferences_in_selection_order(self):
+        """The column lists a respondent's chosen projects, comma separated."""
+        survey = SurveyFactory(session=None)
+        session = SessionFactory.create(application_survey=survey)
+        user = UserFactory.create()
+        response = UserSurveyResponseFactory(survey=survey, user=user)
+
+        project_a = ProjectFactory.create(name="Project A")
+        project_b = ProjectFactory.create(name="Project B")
+        ProjectPreferenceFactory.create(user=user, session=session, project=project_a)
+        ProjectPreferenceFactory.create(user=user, session=session, project=project_b)
+
+        obj = self.admin.get_queryset(self._request()).get(pk=response.pk)
+        self.assertEqual(self.admin.project_preferences(obj), "Project A, Project B")
+
+    def test_shows_any_project_when_no_preferences(self):
+        """A respondent with no ProjectPreference rows is okay with any project."""
+        survey = SurveyFactory(session=None)
+        SessionFactory.create(application_survey=survey)
+        response = UserSurveyResponseFactory(survey=survey)
+
+        obj = self.admin.get_queryset(self._request()).get(pk=response.pk)
+        self.assertEqual(self.admin.project_preferences(obj), "Any project")
+
+    def test_blank_when_survey_has_no_session(self):
+        """The column is empty when the survey isn't tied to an application session."""
+        survey = SurveyFactory(session=None)
+        response = UserSurveyResponseFactory(survey=survey)
+
+        obj = self.admin.get_queryset(self._request()).get(pk=response.pk)
+        self.assertEqual(self.admin.project_preferences(obj), "")
+
+    def _request(self):
+        superuser = UserFactory.create(is_staff=True, is_superuser=True)
+
+        class FakeRequest:
+            user = superuser
+
+        return FakeRequest()

--- a/home/tests/test_forms.py
+++ b/home/tests/test_forms.py
@@ -8,6 +8,8 @@ from django.test import SimpleTestCase, TestCase
 from django.utils import timezone
 
 from accounts.factories import UserFactory
+from home.factories import ProjectFactory
+from home.factories import ProjectPreferenceFactory
 from home.factories import QuestionFactory, SessionFactory
 from home.factories import SurveyFactory
 from home.factories import UserSurveyResponseFactory
@@ -472,6 +474,112 @@ class SurveyCSVExportFormTests(TestCase):
         self.assertEqual(response1_row[5], "Correct")
         self.assertEqual(response2_row[5], "")  # No tutorial evaluation
 
+    def test_generate_full_csv_includes_project_preferences(self):
+        """Test project columns are named for the project and mark interest."""
+        session = SessionFactory.create(application_survey=self.survey)
+        project_a = ProjectFactory.create(name="Project A")
+        project_b = ProjectFactory.create(name="Project B")
+        project_c = ProjectFactory.create(name="Project C")
+        session.available_projects.add(project_a, project_b, project_c)
+
+        ProjectPreferenceFactory.create(
+            user=self.respondent1, session=session, project=project_a
+        )
+        ProjectPreferenceFactory.create(
+            user=self.respondent1, session=session, project=project_b
+        )
+        ProjectPreferenceFactory.create(
+            user=self.respondent2, session=session, project=project_c
+        )
+
+        form = SurveyCSVExportForm(data={"scorer_names": ""})
+        self.assertTrue(form.is_valid())
+
+        response = form.generate_full_csv(self.survey)
+
+        content = response.content.decode("utf-8-sig")
+        csv_reader = csv.reader(io.StringIO(content))
+        rows = list(csv_reader)
+
+        expected_header = [
+            "Response ID",
+            "Submitter Name",
+            "What is your email?",
+            "Rate your experience",
+            "Tell us about yourself",
+            "Project A",
+            "Project B",
+            "Project C",
+            "Tutorial Result",
+            "Score",
+            "Selection Rank",
+        ]
+        self.assertEqual(rows[0], expected_header)
+
+        response1_row = next(row for row in rows if row[0] == str(self.response1.id))
+        response2_row = next(row for row in rows if row[0] == str(self.response2.id))
+        self.assertEqual(response1_row[5], "Yes")  # Project A: interested
+        self.assertEqual(response1_row[6], "Yes")  # Project B: interested
+        self.assertEqual(response1_row[7], "")  # Project C: not interested
+        self.assertEqual(response2_row[5], "")  # Project A: not interested
+        self.assertEqual(response2_row[6], "")  # Project B: not interested
+        self.assertEqual(response2_row[7], "Yes")  # Project C: interested
+
+    def test_generate_full_csv_project_preferences_default_to_any_when_none_selected(
+        self,
+    ):
+        """A respondent with no ProjectPreference rows is okay with any project."""
+        session = SessionFactory.create(application_survey=self.survey)
+        project_a = ProjectFactory.create(name="Project A")
+        project_b = ProjectFactory.create(name="Project B")
+        session.available_projects.add(project_a, project_b)
+
+        # respondent1 selects both projects; respondent2 selects none, meaning
+        # they're okay with any project (see ProjectPreference model docs).
+        ProjectPreferenceFactory.create(
+            user=self.respondent1, session=session, project=project_a
+        )
+        ProjectPreferenceFactory.create(
+            user=self.respondent1, session=session, project=project_b
+        )
+
+        form = SurveyCSVExportForm(data={"scorer_names": ""})
+        self.assertTrue(form.is_valid())
+
+        response = form.generate_full_csv(self.survey)
+
+        content = response.content.decode("utf-8-sig")
+        csv_reader = csv.reader(io.StringIO(content))
+        rows = list(csv_reader)
+
+        response1_row = next(row for row in rows if row[0] == str(self.response1.id))
+        response2_row = next(row for row in rows if row[0] == str(self.response2.id))
+        self.assertEqual(response1_row[5], "Yes")  # Project A: interested
+        self.assertEqual(response1_row[6], "Yes")  # Project B: interested
+        self.assertEqual(response2_row[5], "Yes")  # No preferences: okay with any
+        self.assertEqual(response2_row[6], "Yes")  # No preferences: okay with any
+
+    def test_generate_full_csv_project_columns_show_even_without_any_preferences(self):
+        """Project columns come from the session's available projects, not just
+        from ones someone happened to prefer - so they still appear even when
+        nobody has submitted a ProjectPreference yet."""
+        session = SessionFactory.create(application_survey=self.survey)
+        project_a = ProjectFactory.create(name="Project A")
+        session.available_projects.add(project_a)
+
+        form = SurveyCSVExportForm(data={"scorer_names": ""})
+        self.assertTrue(form.is_valid())
+
+        response = form.generate_full_csv(self.survey)
+
+        content = response.content.decode("utf-8-sig")
+        csv_reader = csv.reader(io.StringIO(content))
+        rows = list(csv_reader)
+
+        self.assertIn("Project A", rows[0])
+        response1_row = next(row for row in rows if row[0] == str(self.response1.id))
+        self.assertEqual(response1_row[rows[0].index("Project A")], "Yes")
+
     def test_generate_single_scorer_csv(self):
         """Test single scorer CSV only includes TEXT_AREA questions."""
         form = SurveyCSVExportForm(data={"scorer_names": ""})
@@ -499,6 +607,46 @@ class SurveyCSVExportFormTests(TestCase):
             rows[1][1], "I am a Django developer with 5 years of experience."
         )
         self.assertEqual(rows[1][2], "")
+
+    def test_generate_single_scorer_csv_includes_project_preferences(self):
+        """Test single scorer CSV columns are named for the project and mark interest."""
+        session = SessionFactory.create(application_survey=self.survey)
+        project_a = ProjectFactory.create(name="Project A")
+        project_b = ProjectFactory.create(name="Project B")
+        session.available_projects.add(project_a, project_b)
+
+        ProjectPreferenceFactory.create(
+            user=self.respondent1, session=session, project=project_a
+        )
+        ProjectPreferenceFactory.create(
+            user=self.respondent1, session=session, project=project_b
+        )
+
+        form = SurveyCSVExportForm(data={"scorer_names": ""})
+        self.assertTrue(form.is_valid())
+
+        response = form.generate_single_scorer_csv(self.survey)
+
+        content = response.content.decode("utf-8-sig")
+        csv_reader = csv.reader(io.StringIO(content))
+        rows = list(csv_reader)
+
+        expected_header = [
+            "Response ID",
+            "Tell us about yourself",
+            "Tell us about yourself Score",
+            "Project A",
+            "Project B",
+        ]
+        self.assertEqual(rows[0], expected_header)
+
+        response1_row = next(row for row in rows if row[0] == str(self.response1.id))
+        response2_row = next(row for row in rows if row[0] == str(self.response2.id))
+        self.assertEqual(response1_row[3], "Yes")
+        self.assertEqual(response1_row[4], "Yes")
+        # respondent2 has no ProjectPreference rows, so they're okay with any project.
+        self.assertEqual(response2_row[3], "Yes")
+        self.assertEqual(response2_row[4], "Yes")
 
     def test_generate_csv_routes_to_full(self):
         """Test generate_csv method routes to full CSV by default."""

--- a/home/tests/test_forms.py
+++ b/home/tests/test_forms.py
@@ -2,6 +2,7 @@ import csv
 import io
 from datetime import date, timedelta
 
+import factory
 from django.contrib.auth import get_user_model
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import SimpleTestCase, TestCase
@@ -474,112 +475,6 @@ class SurveyCSVExportFormTests(TestCase):
         self.assertEqual(response1_row[5], "Correct")
         self.assertEqual(response2_row[5], "")  # No tutorial evaluation
 
-    def test_generate_full_csv_includes_project_preferences(self):
-        """Test project columns are named for the project and mark interest."""
-        session = SessionFactory.create(application_survey=self.survey)
-        project_a = ProjectFactory.create(name="Project A")
-        project_b = ProjectFactory.create(name="Project B")
-        project_c = ProjectFactory.create(name="Project C")
-        session.available_projects.add(project_a, project_b, project_c)
-
-        ProjectPreferenceFactory.create(
-            user=self.respondent1, session=session, project=project_a
-        )
-        ProjectPreferenceFactory.create(
-            user=self.respondent1, session=session, project=project_b
-        )
-        ProjectPreferenceFactory.create(
-            user=self.respondent2, session=session, project=project_c
-        )
-
-        form = SurveyCSVExportForm(data={"scorer_names": ""})
-        self.assertTrue(form.is_valid())
-
-        response = form.generate_full_csv(self.survey)
-
-        content = response.content.decode("utf-8-sig")
-        csv_reader = csv.reader(io.StringIO(content))
-        rows = list(csv_reader)
-
-        expected_header = [
-            "Response ID",
-            "Submitter Name",
-            "What is your email?",
-            "Rate your experience",
-            "Tell us about yourself",
-            "Project A",
-            "Project B",
-            "Project C",
-            "Tutorial Result",
-            "Score",
-            "Selection Rank",
-        ]
-        self.assertEqual(rows[0], expected_header)
-
-        response1_row = next(row for row in rows if row[0] == str(self.response1.id))
-        response2_row = next(row for row in rows if row[0] == str(self.response2.id))
-        self.assertEqual(response1_row[5], "Yes")  # Project A: interested
-        self.assertEqual(response1_row[6], "Yes")  # Project B: interested
-        self.assertEqual(response1_row[7], "")  # Project C: not interested
-        self.assertEqual(response2_row[5], "")  # Project A: not interested
-        self.assertEqual(response2_row[6], "")  # Project B: not interested
-        self.assertEqual(response2_row[7], "Yes")  # Project C: interested
-
-    def test_generate_full_csv_project_preferences_default_to_any_when_none_selected(
-        self,
-    ):
-        """A respondent with no ProjectPreference rows is okay with any project."""
-        session = SessionFactory.create(application_survey=self.survey)
-        project_a = ProjectFactory.create(name="Project A")
-        project_b = ProjectFactory.create(name="Project B")
-        session.available_projects.add(project_a, project_b)
-
-        # respondent1 selects both projects; respondent2 selects none, meaning
-        # they're okay with any project (see ProjectPreference model docs).
-        ProjectPreferenceFactory.create(
-            user=self.respondent1, session=session, project=project_a
-        )
-        ProjectPreferenceFactory.create(
-            user=self.respondent1, session=session, project=project_b
-        )
-
-        form = SurveyCSVExportForm(data={"scorer_names": ""})
-        self.assertTrue(form.is_valid())
-
-        response = form.generate_full_csv(self.survey)
-
-        content = response.content.decode("utf-8-sig")
-        csv_reader = csv.reader(io.StringIO(content))
-        rows = list(csv_reader)
-
-        response1_row = next(row for row in rows if row[0] == str(self.response1.id))
-        response2_row = next(row for row in rows if row[0] == str(self.response2.id))
-        self.assertEqual(response1_row[5], "Yes")  # Project A: interested
-        self.assertEqual(response1_row[6], "Yes")  # Project B: interested
-        self.assertEqual(response2_row[5], "Yes")  # No preferences: okay with any
-        self.assertEqual(response2_row[6], "Yes")  # No preferences: okay with any
-
-    def test_generate_full_csv_project_columns_show_even_without_any_preferences(self):
-        """Project columns come from the session's available projects, not just
-        from ones someone happened to prefer - so they still appear even when
-        nobody has submitted a ProjectPreference yet."""
-        session = SessionFactory.create(application_survey=self.survey)
-        project_a = ProjectFactory.create(name="Project A")
-        session.available_projects.add(project_a)
-
-        form = SurveyCSVExportForm(data={"scorer_names": ""})
-        self.assertTrue(form.is_valid())
-
-        response = form.generate_full_csv(self.survey)
-
-        content = response.content.decode("utf-8-sig")
-        csv_reader = csv.reader(io.StringIO(content))
-        rows = list(csv_reader)
-
-        self.assertIn("Project A", rows[0])
-        response1_row = next(row for row in rows if row[0] == str(self.response1.id))
-        self.assertEqual(response1_row[rows[0].index("Project A")], "Yes")
-
     def test_generate_single_scorer_csv(self):
         """Test single scorer CSV only includes TEXT_AREA questions."""
         form = SurveyCSVExportForm(data={"scorer_names": ""})
@@ -607,46 +502,6 @@ class SurveyCSVExportFormTests(TestCase):
             rows[1][1], "I am a Django developer with 5 years of experience."
         )
         self.assertEqual(rows[1][2], "")
-
-    def test_generate_single_scorer_csv_includes_project_preferences(self):
-        """Test single scorer CSV columns are named for the project and mark interest."""
-        session = SessionFactory.create(application_survey=self.survey)
-        project_a = ProjectFactory.create(name="Project A")
-        project_b = ProjectFactory.create(name="Project B")
-        session.available_projects.add(project_a, project_b)
-
-        ProjectPreferenceFactory.create(
-            user=self.respondent1, session=session, project=project_a
-        )
-        ProjectPreferenceFactory.create(
-            user=self.respondent1, session=session, project=project_b
-        )
-
-        form = SurveyCSVExportForm(data={"scorer_names": ""})
-        self.assertTrue(form.is_valid())
-
-        response = form.generate_single_scorer_csv(self.survey)
-
-        content = response.content.decode("utf-8-sig")
-        csv_reader = csv.reader(io.StringIO(content))
-        rows = list(csv_reader)
-
-        expected_header = [
-            "Response ID",
-            "Tell us about yourself",
-            "Tell us about yourself Score",
-            "Project A",
-            "Project B",
-        ]
-        self.assertEqual(rows[0], expected_header)
-
-        response1_row = next(row for row in rows if row[0] == str(self.response1.id))
-        response2_row = next(row for row in rows if row[0] == str(self.response2.id))
-        self.assertEqual(response1_row[3], "Yes")
-        self.assertEqual(response1_row[4], "Yes")
-        # respondent2 has no ProjectPreference rows, so they're okay with any project.
-        self.assertEqual(response2_row[3], "Yes")
-        self.assertEqual(response2_row[4], "Yes")
 
     def test_generate_csv_routes_to_full(self):
         """Test generate_csv method routes to full CSV by default."""
@@ -681,6 +536,146 @@ class SurveyCSVExportFormTests(TestCase):
 
         # Check BOM is present
         self.assertTrue(response.content.startswith(b"\xef\xbb\xbf"))
+
+
+class SurveyCSVExportProjectPreferencesTests(TestCase):
+    """Test project preference columns in SurveyCSVExportForm CSV generation."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.respondent1 = User.objects.create_user(
+            username="pref-user1",
+            email="pref-user1@example.com",
+            first_name="John",
+            last_name="Doe",
+        )
+        cls.respondent2 = User.objects.create_user(
+            username="pref-user2",
+            email="pref-user2@example.com",
+            first_name="Jane",
+            last_name="Smith",
+        )
+        cls.survey = SurveyFactory.create(name="Preferences Survey")
+        cls.response1 = UserSurveyResponse.objects.create(
+            survey=cls.survey, user=cls.respondent1
+        )
+        cls.response2 = UserSurveyResponse.objects.create(
+            survey=cls.survey, user=cls.respondent2
+        )
+
+        cls.session = SessionFactory.create(application_survey=cls.survey)
+        cls.project_a, cls.project_b, cls.project_c = ProjectFactory.create_batch(
+            3, name=factory.Iterator(["Project A", "Project B", "Project C"])
+        )
+        cls.session.available_projects.add(cls.project_a, cls.project_b, cls.project_c)
+
+    @staticmethod
+    def _rows(response):
+        content = response.content.decode("utf-8-sig")
+        return list(csv.reader(io.StringIO(content)))
+
+    def test_marks_interest_in_selected_projects(self):
+        """Each project gets its own column, marked "Yes" only when preferred."""
+        ProjectPreferenceFactory.create(
+            user=self.respondent1, session=self.session, project=self.project_a
+        )
+        ProjectPreferenceFactory.create(
+            user=self.respondent1, session=self.session, project=self.project_b
+        )
+        ProjectPreferenceFactory.create(
+            user=self.respondent2, session=self.session, project=self.project_c
+        )
+
+        form = SurveyCSVExportForm(data={"scorer_names": ""})
+        self.assertTrue(form.is_valid())
+        rows = self._rows(form.generate_full_csv(self.survey))
+        header = rows[0]
+
+        response1_row = next(row for row in rows if row[0] == str(self.response1.id))
+        response2_row = next(row for row in rows if row[0] == str(self.response2.id))
+        self.assertEqual(response1_row[header.index("Project A")], "Yes")
+        self.assertEqual(response1_row[header.index("Project B")], "Yes")
+        self.assertEqual(response1_row[header.index("Project C")], "")
+        self.assertEqual(response2_row[header.index("Project A")], "")
+        self.assertEqual(response2_row[header.index("Project B")], "")
+        self.assertEqual(response2_row[header.index("Project C")], "Yes")
+
+    def test_defaults_to_any_project_when_none_selected(self):
+        """A respondent with no ProjectPreference rows is okay with any project."""
+        # respondent1 selects a project; respondent2 selects none, meaning
+        # they're okay with any project (see ProjectPreference model docs).
+        ProjectPreferenceFactory.create(
+            user=self.respondent1, session=self.session, project=self.project_a
+        )
+
+        form = SurveyCSVExportForm(data={"scorer_names": ""})
+        self.assertTrue(form.is_valid())
+        rows = self._rows(form.generate_full_csv(self.survey))
+        header = rows[0]
+
+        response2_row = next(row for row in rows if row[0] == str(self.response2.id))
+        self.assertEqual(response2_row[header.index("Project A")], "Yes")
+        self.assertEqual(response2_row[header.index("Project B")], "Yes")
+        self.assertEqual(response2_row[header.index("Project C")], "Yes")
+
+    def test_columns_show_even_without_any_preferences_submitted(self):
+        """Columns come from the session's available projects, not just ones
+        someone happened to prefer - so they appear before anyone responds."""
+        form = SurveyCSVExportForm(data={"scorer_names": ""})
+        self.assertTrue(form.is_valid())
+        rows = self._rows(form.generate_full_csv(self.survey))
+        header = rows[0]
+
+        self.assertIn("Project A", header)
+        response1_row = next(row for row in rows if row[0] == str(self.response1.id))
+        self.assertEqual(response1_row[header.index("Project A")], "Yes")
+
+    def test_full_csv_places_project_columns_before_scoring(self):
+        """Project columns land after any question columns and before scoring."""
+        form = SurveyCSVExportForm(data={"scorer_names": ""})
+        self.assertTrue(form.is_valid())
+        rows = self._rows(form.generate_full_csv(self.survey))
+        header = rows[0]
+
+        self.assertEqual(header[:2], ["Response ID", "Submitter Name"])
+        self.assertEqual(header[-3:], ["Tutorial Result", "Score", "Selection Rank"])
+        self.assertLess(header.index("Project A"), header.index("Tutorial Result"))
+
+    def test_single_scorer_csv_marks_interest_in_selected_projects(self):
+        """The single scorer CSV gets the same project columns as the full one."""
+        ProjectPreferenceFactory.create(
+            user=self.respondent1, session=self.session, project=self.project_a
+        )
+        ProjectPreferenceFactory.create(
+            user=self.respondent1, session=self.session, project=self.project_b
+        )
+
+        form = SurveyCSVExportForm(data={"scorer_names": ""})
+        self.assertTrue(form.is_valid())
+        rows = self._rows(form.generate_single_scorer_csv(self.survey))
+        header = rows[0]
+
+        response1_row = next(row for row in rows if row[0] == str(self.response1.id))
+        response2_row = next(row for row in rows if row[0] == str(self.response2.id))
+        self.assertEqual(response1_row[header.index("Project A")], "Yes")
+        self.assertEqual(response1_row[header.index("Project B")], "Yes")
+        # respondent2 has no ProjectPreference rows, so they're okay with any project.
+        self.assertEqual(response2_row[header.index("Project A")], "Yes")
+        self.assertEqual(response2_row[header.index("Project B")], "Yes")
+
+    def test_single_scorer_csv_columns_show_even_without_any_preferences_submitted(
+        self,
+    ):
+        """Single scorer CSV columns also come from available projects, not
+        just from selected preferences."""
+        form = SurveyCSVExportForm(data={"scorer_names": ""})
+        self.assertTrue(form.is_valid())
+        rows = self._rows(form.generate_single_scorer_csv(self.survey))
+        header = rows[0]
+
+        self.assertIn("Project A", header)
+        response1_row = next(row for row in rows if row[0] == str(self.response1.id))
+        self.assertEqual(response1_row[header.index("Project A")], "Yes")
 
 
 class SurveyCSVImportFormTests(TestCase):


### PR DESCRIPTION
This adds the project preferences as columns to both styles of CSV exports for applicants and includes it as a column on the User Survey Response page.